### PR TITLE
serverless-dir-config-plugin

### DIFF
--- a/plugins.json
+++ b/plugins.json
@@ -208,4 +208,10 @@
   "name": "serverless-plugin-encode-env-var-objects",
   "description": "Serverless plugin to encode any environment variable objects.",
   "githubUrl": "https://github.com/yonomi/serverless-plugin-encode-env-var-objects"
-}]
+},
+  {
+     "name": "serverless-dir-config-plugin",
+  "description": "EXPERIMENTAL - Serverless plugin to load function and resource definitions from a directory.",
+  "githubUrl": "https://github.com/economysizegeek/serverless-dir-config-plugin"
+  }
+]


### PR DESCRIPTION
Points at a plugin to load up configuration from a directory structure in addition to the main serverless.yml.  This makes it easier to mange a lot of definitions.