### PR TITLE
Add serverless dotenv plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ If you have ideas for features or plugins, add a new [thread](https://github.com
 | **[Serverless Command Line Event Args](https://github.com/horike37/serverless-command-line-event-args)** <br/> This module is Serverless Framework plugin. Event JSON passes to your Lambda function in commandline. | [horike37](http://github.com/horike37) | 
 | **[Serverless Crypt](https://github.com/marcy-terui/serverless-crypt)** <br/> Securing the secrets on Serverless Framework by AWS KMS encryption. | [marcy-terui](http://github.com/marcy-terui) | 
 | **[Serverless Dir Config Plugin](https://github.com/economysizegeek/serverless-dir-config-plugin)** <br/> EXPERIMENTAL - Serverless plugin to load function and resource definitions from a directory. | [economysizegeek](http://github.com/economysizegeek) | 
+| **[Serverless Dotenv](https://github.com/Jimdo/serverless-dotenv)** <br/> Fetch environment variables and write it to a .env file | [Jimdo](http://github.com/Jimdo) | 
 | **[Serverless Dotnet](https://github.com/fruffin/serverless-dotnet)** <br/> A serverless plugin to run 'dotnet' commands as part of the deploy process | [fruffin](http://github.com/fruffin) | 
 | **[Serverless Dynamodb Local](https://github.com/99xt/serverless-dynamodb-local)** <br/> Serverless Dynamodb Local Plugin - Allows to run dynamodb locally for serverless | [99xt](http://github.com/99xt) | 
 | **[Serverless Enable Api Logs](https://github.com/paulSambolin/serverless-enable-api-logs)** <br/> Enables Coudwatch logging for API Gateway events | [paulSambolin](http://github.com/paulSambolin) | 

--- a/plugins.json
+++ b/plugins.json
@@ -263,5 +263,10 @@
     "name": "serverless-sqs-alarms-plugin",
     "description": "Wrapper to setup CloudWatch Alarms on SQS queue length",
     "githubUrl": "https://github.com/sbstjn/serverless-sqs-alarms-plugin"
-  }   
+  },
+  {
+    "name": "serverless-dotenv",
+    "description": "Fetch environment variables and write it to a .env file",
+    "githubUrl": "https://github.com/Jimdo/serverless-dotenv"
+  }
 ]


### PR DESCRIPTION
Hi,

we wrote a small plugin to extend the functionality of the serverless framework. We hope that you will like the plugin and can't wait to hear your feedback.

Thanks and have a nice day ;) 

---

## About the plugin

In combination with the `serverless-offline` plugin and integration tests it was useful for us to render the environment variables of the serverless configuration and save it to a `.env` file. With this approach we could easily run integration tests based on the current stack. The plugin is generic enough to simple fetch all environment variables and use it for other cases. 

## How it works

We provide two ways to use this plugin: 

1. You can run the plugin directly via the command line tool, this will walk through your `serverless.yml` and grab all environment variables provided on root level as well as in every function.
2. You can start `serverless offline` and the plugin will hook into the process and grab all environment variables right before serverless offline is executed. It will also add two additional environment variables: `IS_OFFLINE` and `API_ENDPOINT`. In combination with the great [execution feature](https://github.com/dherault/serverless-offline#scoped-execution) of `serverless-offline` you can easily start your full stack, run your integration tests and teardown everything. 