### PR TITLE
Add serverless-hooks-plugin.

### DIFF
--- a/plugins.json
+++ b/plugins.json
@@ -268,5 +268,10 @@
     "name": "serverless-dotenv",
     "description": "Fetch environment variables and write it to a .env file",
     "githubUrl": "https://github.com/Jimdo/serverless-dotenv"
+  },
+    {
+    "name": "serverless-hooks-plugin",
+    "description": "Run arbitrary commands on any lifecycle event in serverless",
+    "githubUrl": "https://github.com/uswitch/serverless-hooks-plugin"
   }
 ]


### PR DESCRIPTION
Hi there!

I wrote a small plugin to allow hooking into any `lifecycleEvent` any package might provide to run arbitrary code (in the context of the shell running the commands), mostly to solve my personal problem of wanting to be able to run commands like `lein uberjar` prior to deploying!

Hopefully this is a useful thing, I wasn't able to find anything that provides the same functionality 😄 