### PR TITLE
Add serverless-dynalite to plugin list

### DIFF
--- a/plugins.json
+++ b/plugins.json
@@ -278,5 +278,5 @@
     "name": "serverless-dynalite",
     "description": "Run dynalite locally (no JVM, all JS) to simulate DynamoDB. Watch serverless.yml for table config updates.",
     "githubUrl": "https://github.com/sdd/serverless-dynalite"
-  },
+  }
 ]

--- a/plugins.json
+++ b/plugins.json
@@ -273,5 +273,10 @@
     "name": "serverless-hooks-plugin",
     "description": "Run arbitrary commands on any lifecycle event in serverless",
     "githubUrl": "https://github.com/uswitch/serverless-hooks-plugin"
-  }
+  },
+  {
+    "name": "serverless-dynalite",
+    "description": "Run dynalite locally (no JVM, all JS) to simulate DynamoDB. Watch serverless.yml for table config updates.",
+    "githubUrl": "https://github.com/sdd/serverless-dynalite"
+  },
 ]


### PR DESCRIPTION
Serverless-dynalite is similar to serverless-dynamodb-local except that it uses Dynalite to provide a local dynamodb-like server. Dynalite requires no JVM, only JS.

In addition, this plugin watches `serverless.yml` resources config for DynamoDB table additions, and adds the table to dynalite automatically.