### PR TITLE
Add serverless-apig-s3

### DIFF
--- a/plugins.json
+++ b/plugins.json
@@ -278,5 +278,10 @@
     "name": "serverless-dynalite",
     "description": "Run dynalite locally (no JVM, all JS) to simulate DynamoDB. Watch serverless.yml for table config updates.",
     "githubUrl": "https://github.com/sdd/serverless-dynalite"
+  },
+  {
+    "name": "serverless-apig-s3",
+    "description": "Serve static front-end content from S3 via the API Gatewy and deploy client bundle to S3.",
+    "githubUrl": "https://github.com/sdd/serverless-apig-s3"
   }
 ]


### PR DESCRIPTION
This plugin creates an s3 bucket and some routes via APIG so that an index.html and client bundle can be served. Also adds a client deploy command to upload client bundle to s3. So, it's like `serverless-client-s3` only works with latest serverless and also creates infra to serve content.