### PR TITLE
add serverless-kubeless plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ If you have ideas for features or plugins, add a new [thread](https://github.com
 | **[Serverless Hooks Plugin](https://github.com/uswitch/serverless-hooks-plugin)** <br/> Run arbitrary commands on any lifecycle event in serverless | [uswitch](http://github.com/uswitch) | 
 | **[Serverless Jest Plugin](https://github.com/SC5/serverless-jest-plugin)** <br/> A Serverless Plugin for the Serverless Framework which adds support for test-driven development using Jest | [SC5](http://github.com/SC5) | 
 | **[Serverless Kms Secrets](https://github.com/SC5/serverless-kms-secrets)** <br/> Allows to easily encrypt and decrypt secrets using KMS from the serverless CLI | [SC5](http://github.com/SC5) | 
+| **[Serverless Kubeless](https://github.com/ngtuna/serverless-kubeless)** <br/> Serverless plugin for deploying functions to Kubeless. | [ngtuna](http://github.com/ngtuna) | 
 | **[Serverless Mocha Plugin](https://github.com/SC5/serverless-mocha-plugin)** <br/> A Serverless Plugin for the Serverless Framework which adds support for test-driven development using Mocha | [SC5](http://github.com/SC5) | 
 | **[Serverless Offline](https://github.com/dherault/serverless-offline)** <br/> Emulate AWS λ and API Gateway locally when developing your Serverless project | [dherault](http://github.com/dherault) | 
 | **[Serverless Offline Scheduler](https://github.com/ajmath/serverless-offline-scheduler)** <br/> Runs scheduled functions offline while integrating with serverless-offline | [ajmath](http://github.com/ajmath) | 

--- a/plugins.json
+++ b/plugins.json
@@ -343,5 +343,10 @@
     "name": "serverless-vpc-discovery",
     "description": "Serverless plugin for discovering VPC / Subnet / Security Group configuration by name.",
     "githubUrl": "https://github.com/amplify-education/serverless-vpc-discovery"
+  },
+  {
+    "name": "serverless-kubeless",
+    "description": "Serverless plugin for deploying functions to Kubeless.",
+    "githubUrl": "https://github.com/ngtuna/serverless-kubeless"
   }
 ]


### PR DESCRIPTION
Hi folks,

I am requesting to add serverless-kubeless plugin which helps serverless users to quickly try [Kubeless](https://github.com/bitnami/kubeless), a serverless framework for Kubernetes developed by Bitnami. We had some discussions with @pmuens about this and I am very excited to do this support. Feel free to ask me questions.

Related issue: https://github.com/serverless/serverless/issues/3410

Cheers,