### PR TITLE
Add dynamodb-autoscaling

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ If you have ideas for features or plugins, add a new [thread](https://github.com
 | **[Serverless Dotenv](https://github.com/Jimdo/serverless-dotenv)** <br/> Fetch environment variables and write it to a .env file | [Jimdo](http://github.com/Jimdo) | 
 | **[Serverless Dotnet](https://github.com/fruffin/serverless-dotnet)** <br/> A serverless plugin to run 'dotnet' commands as part of the deploy process | [fruffin](http://github.com/fruffin) | 
 | **[Serverless Dynalite](https://github.com/sdd/serverless-dynalite)** <br/> Run dynalite locally (no JVM, all JS) to simulate DynamoDB. Watch serverless.yml for table config updates. | [sdd](http://github.com/sdd) | 
+| **[Serverless Dynamodb Autoscaling](https://github.com/sbstjn/serverless-dynamodb-autoscaling)** <br/> Configure Amazon DynamoDB's native Auto Scaling for your table capacities. | [sbstjn](http://github.com/sbstjn) | 
 | **[Serverless Dynamodb Local](https://github.com/99xt/serverless-dynamodb-local)** <br/> Serverless Dynamodb Local Plugin - Allows to run dynamodb locally for serverless | [99xt](http://github.com/99xt) | 
 | **[Serverless Dynamodb Ttl](https://github.com/Jimdo/serverless-dynamodb-ttl)** <br/> Configure DynamoDB TTL in serverless.yml (until CloudFormation supports this). | [Jimdo](http://github.com/Jimdo) | 
 | **[Serverless Enable Api Logs](https://github.com/paulSambolin/serverless-enable-api-logs)** <br/> Enables Coudwatch logging for API Gateway events | [paulSambolin](http://github.com/paulSambolin) | 

--- a/plugins.json
+++ b/plugins.json
@@ -418,5 +418,10 @@
     "name": "serverless-s3-remover",
     "description": "A serverless plugin to make s3 buckets empty before deleting cloudformation stack when ```sls remove```",
     "githubUrl": "https://github.com/sinofseven/serverless-s3-remover"
+  },
+  {
+    "name": "serverless-dynamodb-autoscaling",
+    "description": "Configure Amazon DynamoDB's native Auto Scaling for your table capacities.",
+    "githubUrl": "https://github.com/sbstjn/serverless-dynamodb-autoscaling"
   }
 ]


### PR DESCRIPTION
Configure DynamoDB's native Auto Scaling with [serverless-dynamodb-autoscaling](https://github.com/sbstjn/serverless-dynamodb-autoscaling).

### Configuration

```yaml
custom:
  capacities:
    - name: custom-table  # DynamoDB table name
      read:
        minimum: 5        # Minimum read capacity
        maximum: 1000     # Maximum read capacity
        usage: 0.75       # Targeted usage percentage
      write:
        minimum: 40       # Minimum write capacity
        maximum: 200      # Maximum write capacity
        usage: 0.5        # Targeted usage percentage
```

### Result

<img width="776" alt="console" src="https://user-images.githubusercontent.com/248965/28329739-2fe35e62-6beb-11e7-82d5-bbae6dc2bd7c.png">
