### PR TITLE
Adds the serverless-attach-managed-policy

### DIFF
--- a/plugins.json
+++ b/plugins.json
@@ -548,5 +548,10 @@
     "name": "serverless-aws-resource-names",
     "description": "Serverless plugin to alter the default naming conventions for sls resources via a simple mapping file.",
     "githubUrl": "https://github.com/concon121/serverless-plugin-aws-resource-names"
+  },
+  {
+    "name": "serverless-attach-managed-policy",
+    "description": "A Serverless plugin to automatically attach an AWS Managed IAM Policy (or Policies) to all IAM Roles created by the Service.",
+    "githubUrl": "https://github.com/Nordstrom/serverless-attach-managed-policy"
   }
 ]


### PR DESCRIPTION
Company policy requires any AWS Role provisioned for any service to have a specific Managed Policy applied to it for management purposes. Any Role not explicitly including the Policy will be modified to include the Policy after deployment. In such cases, the service will not be able to remove any Roles modified after deployment, causing an error during stack removal.

That peppering of the `ManagedPolicyArns` property throughout the service's Role definitions would not be necessary with this plugin. That is a nice to have, and saves us some noise and reduces potential errors due to omitting the policy by accident.

Where it became a blocker is when we have a serverless plugin that generates its own roles. The DynamoDB Auto-scaling plugin is an example. Since it creates the roles and adds them to the CFT for us, we cannot actually reference them in our service definition.

This plugin is invoked just before the service is going to be deployed. At that point, the other plugins should have added any roles to the CFT. This plugin will look at each of the roles in the template and attach the requested Managed Policies.