### PR TITLE
Add serverless-sns-filter

### DIFF
--- a/plugins.json
+++ b/plugins.json
@@ -593,5 +593,10 @@
     "name": "serverless-iot-local",
     "description": "AWS Iot events with serverless-offline",
     "githubUrl": "https://github.com/tradle/serverless-iot-local"
+  },
+  {
+    "name": "serverless-sns-filter",
+    "description": "Serverless plugin to add SNS Subscription Filters to events",
+    "githubUrl": "https://github.com/MechanicalRock/serverless-sns-filter"
   }
 ]


### PR DESCRIPTION
Add reference to Serverless plugin that adds ability to specify SNS Subscription Filters for function definitions.

I'm currently in the process of publishing to NPM.