### PR TITLE
Add serverless-apib-validator

### DIFF
--- a/plugins.json
+++ b/plugins.json
@@ -703,5 +703,10 @@
     "name": "serverless-go-build",
     "description": "Build go source files (or public functions) using yml definition file",
     "githubUrl": "https://github.com/sean9keenan/serverless-go-build"
+  },
+  {
+    "name": "serverless-apib-validator",
+    "description": "Validate that an API Blueprint has full coverage over a Serverless config",
+    "githubUrl": "https://github.com/onlicar/serverless-apib-validator"
   }
 ]


### PR DESCRIPTION
Before deploying, this Serverless plugin will parse an API blueprint from the config and validate that every lambda function with an HTTP event is documented.