### PR TITLE
Add serverless-package-common

### DIFF
--- a/plugins.json
+++ b/plugins.json
@@ -703,5 +703,10 @@
     "name": "serverless-go-build",
     "description": "Build go source files (or public functions) using yml definition file",
     "githubUrl": "https://github.com/sean9keenan/serverless-go-build"
+  },
+  {
+    "name": "serverless-package-common",
+    "description": "Deploy microservice Python Serverless services with common code",
+    "githubUrl": "https://github.com/onlicar/serverless-package-common"
   }
 ]


### PR DESCRIPTION
Before deploying, this plugin symlinks folders containing shared code into the root directory of your Serverless microservice.

Although it's similar to serverless-custom-packaging-plugin, this plugin purely solves the additional libraries problem so it's not going to break so easily for our use case.