### PR TITLE
add serverless-cdk-plugin to the list

### DIFF
--- a/plugins.json
+++ b/plugins.json
@@ -1,4 +1,9 @@
 [{
+    "name": "@swarmion/serverless-cdk-plugin",
+    "description": "Use the CDK as a cloudformation generator fed to the serverless deployment process. Requires typescript.",
+    "githubUrl": "https://github.com/swarmion/swarmion/tree/main/packages/serverless-cdk-plugin",
+    "status": "active"
+},{
     "name": "@kakkuk/serverless-aws-lambda-dynamic-trigger",
     "description": "Allows to register sns, sqs and kinesis triggers (events) dynamically.",
     "githubUrl": "https://github.com/failsafe-engineering/serverless-aws-lambda-dynamic-trigger",


### PR DESCRIPTION
Proposing to add the @swarmion/serverless-cdk-plugin https://www.npmjs.com/package/@swarmion/serverless-cdk-plugin to the list of serverless plugins.

Create resources using the AWS CDK (SQS, Dynamodb, etc.) and reference them in the Serverless framework configuration's serverless.ts. Serverless then provisions your lambdas AND your other resources!