### PR TITLE
add serverless remote json envs plugin

### DIFF
--- a/plugins.json
+++ b/plugins.json
@@ -229,7 +229,6 @@
     "description": "Offline support for serverless-appsync-plugin",
     "githubUrl": "https://github.com/bboure/serverless-appsync-simulator",
     "status": "active"
-}, 
 }, {
     "name": "serverless-remote-json-envs",
     "description": "Allows to use plain JSON files in remote locations being parsed as environment variables in lambda",

--- a/plugins.json
+++ b/plugins.json
@@ -230,7 +230,7 @@
     "githubUrl": "https://github.com/bboure/serverless-appsync-simulator",
     "status": "active"
 }, 
- }, {
+}, {
     "name": "serverless-remote-json-envs",
     "description": "Allows to use plain JSON files in remote locations being parsed as environment variables in lambda",
     "githubUrl": "https://github.com/juancarestre/serverless-remote-json-envs",

--- a/plugins.json
+++ b/plugins.json
@@ -229,7 +229,14 @@
     "description": "Offline support for serverless-appsync-plugin",
     "githubUrl": "https://github.com/bboure/serverless-appsync-simulator",
     "status": "active"
-}, {
+}, 
+ }, {
+    "name": "serverless-remote-json-envs",
+    "description": "Allows to use plain JSON files in remote locations being parsed as environment variables in lambda",
+    "githubUrl": "https://github.com/juancarestre/serverless-remote-json-envs",
+    "status": "active"
+}, 
+ {
     "name": "serverless-plugin-tag-cloud-watch-logs",
     "description": "Small serverless plugin providing a way to add tags to CloudWatch resources",
     "githubUrl": "https://github.com/pretty-fun-therapy/serverless-plugin-tag-cloud-watch-logs",

--- a/plugins.json
+++ b/plugins.json
@@ -235,8 +235,7 @@
     "description": "Allows to use plain JSON files in remote locations being parsed as environment variables in lambda",
     "githubUrl": "https://github.com/juancarestre/serverless-remote-json-envs",
     "status": "active"
-}, 
- {
+}, {
     "name": "serverless-plugin-tag-cloud-watch-logs",
     "description": "Small serverless plugin providing a way to add tags to CloudWatch resources",
     "githubUrl": "https://github.com/pretty-fun-therapy/serverless-plugin-tag-cloud-watch-logs",


### PR DESCRIPTION
This Serverless Framework Plugin allows to use plain JSON files in remote locations being parsed as environment variables in a lambda, this unlocks ability to do integrations with anothers services, apps and/or SSM ParameterStore, S3 to save many environment variables in a single parameters key as a JSON.