### PR TITLE
Add serverless-configure-lambda-logs plugin

### DIFF
--- a/plugins.json
+++ b/plugins.json
@@ -1845,7 +1845,7 @@
   {
     "name": "serverless-configure-lambda-logs",
     "description": "Plugin that configures Lambda logs with CloudWatch log groups and subscriptions",
-    "githubUrl": "https://github.com/vavasilva/serverless-configure-lamba-logs",
+    "githubUrl": "https://github.com/vavasilva/serverless-configure-lambda-logs",
     "status": "active"
   }
 ]

--- a/plugins.json
+++ b/plugins.json
@@ -1,1742 +1,2086 @@
-[{
+[
+  {
     "name": "@kakkuk/serverless-aws-lambda-dynamic-trigger",
     "description": "Allows to register sns, sqs and kinesis triggers (events) dynamically.",
     "githubUrl": "https://github.com/failsafe-engineering/serverless-aws-lambda-dynamic-trigger",
     "status": "active"
-},{
+  },
+  {
     "name": "@kakkuk/serverless-aws-apigateway-documentation",
     "description": "Adds support for AWS API Gateway documentation and model",
     "githubUrl": "https://github.com/failsafe-engineering/serverless-aws-apigateway-documentation",
     "status": "active"
-},{
+  },
+  {
     "name": "@vulcancreative/serverless-storage",
     "description": "Serverless plugin defining DynamoDB storage primitives; like localStorage but better",
     "githubUrl": "https://github.com/vulcancreative/serverless-storage",
     "status": "active"
-},{
+  },
+  {
     "name": "serverless-aws-function-url-custom-domain",
     "description": "Setup cloudfront distrubution and route53 record for AWS Lambda with Function URL",
     "githubUrl": "https://github.com/wangsha/serverless-aws-function-url-custom-domain",
     "status": "active"
-},{
+  },
+  {
     "name": "serverless-plugin-typetalk",
     "description": "Sends notification to Typetalk",
     "githubUrl": "https://github.com/is2ei/serverless-plugin-typetalk",
     "status": "active"
-}, {
+  },
+  {
     "name": "serverless-aws-lambda",
     "description": "Plug & Play AWS Lambda NodeJS development tool with local API Gateway and Application Load Balancer support.",
     "githubUrl": "https://github.com/Inqnuam/serverless-aws-lambda",
     "status": "active"
-},{
+  },
+  {
     "name": "serverless-app-client-credentials-to-ssm",
     "description": "Export Cognito app client credentials to SSM Parameter store",
     "githubUrl": "https://github.com/GaaraZhu/serverless-app-client-credentials-to-ssm",
     "status": "active"
-}, {
+  },
+  {
     "name": "serverless-prune-versions",
     "description": "Automatic deletion of old Lambda and Lambda Layer versions",
     "githubUrl": "https://github.com/manwaring/serverless-prune-versions",
     "status": "active"
-}, {
+  },
+  {
     "name": "serverless-log-metric-filter",
     "description": "Add Cloudwatch Log Metric Filter to Cloudwatch Logs",
     "githubUrl": "https://github.com/saqemlas/serverless-log-metric-filter",
     "status": "active"
-},
-{
+  },
+  {
     "name": "serverless-plugin-sumologic",
     "description": "This Serverless plugin deploys Cloudformation Stack with resources required to send Cloudformation Logs to Sumologic. This stack uses AWS Lambda to subscribe to your CloudWatch Log Group and POSTs the log data directly to Sumo HTTP Source.",
     "githubUrl": "https://github.com/ACloudGuru/serverless-plugin-sumologic",
     "status": "active"
-}, {
+  },
+  {
     "name": "serverless-plugin-apollo-graphql-federation",
     "description": "A Serverless Framework that uploads a graphql schema to the Apollo Platform managed federation service",
     "githubUrl": "https://github.com/Imran99/serverless-plugin-apollo-graphql-federation",
     "status": "active"
-}, {
+  },
+  {
     "name": "serverless-plugin-modularize",
     "description": "Modularize your serverless definitions",
     "githubUrl": "https://github.com/icarus-sullivan/serverless-plugin-modularize",
     "status": "active"
-}, {
+  },
+  {
     "name": "@stratiformdigital/serverless-online",
     "description": "Faster lambda development in AWS through hot deploys and streaming logs.",
     "githubUrl": "https://github.com/stratiformdigital/serverless-online",
     "status": "active"
-}, {
+  },
+  {
     "name": "@stratiformdigital/serverless-iam-helper",
     "description": "Applies IAM Path and PermissionsBoundary settings in hard to reach places.",
     "githubUrl": "https://github.com/stratiformdigital/serverless-iam-helper",
     "status": "active"
-}, {
+  },
+  {
     "name": "@stratiformdigital/serverless-idempotency-helper",
     "description": "Helps make lambda deployments idempotent",
     "githubUrl": "https://github.com/stratiformdigital/serverless-idempotency-helper",
     "status": "active"
-}, {
+  },
+  {
     "name": "@stratiformdigital/serverless-s3-security-helper",
     "description": "Sets security minded settings on s3 buckets, including sls deployment buckets",
     "githubUrl": "https://github.com/stratiformdigital/serverless-s3-security-helper",
     "status": "active"
-}, {
+  },
+  {
     "name": "serverless-provisioned-concurrency-autoscaling",
     "description": "Serverless Plugin for AWS Lambda Provisioned Concurrency Auto Scaling configuration",
     "githubUrl": "https://github.com/neiman-marcus/serverless-provisioned-concurrency-autoscaling",
     "status": "active"
-}, {
+  },
+  {
     "name": "serverless-localstack",
     "description": "Serverless plugin for LocalStack - a fully functional local AWS cloud stack. Develop and test your cloud & Serverless apps offline!",
     "githubUrl": "https://github.com/LocalStack/serverless-localstack",
     "status": "active"
-}, {
+  },
+  {
     "name": "serverless-commercetools-plugin",
     "description": "Serverless framework plugin that registers the deployed function as a commercetools API Extension or attaches it to a Subscription.",
     "githubUrl": "https://github.com/commercetools/serverless-commercetools-plugin",
     "status": "active"
-}, {
+  },
+  {
     "name": "serverless-plugin-test-helper",
     "description": "Makes it easier to end-to-end test deployed deployed services by saving CloudFormation Stack Outputs locally and exposing values via a simple Node.js library",
     "githubUrl": "https://github.com/manwaring/serverless-plugin-test-helper",
     "status": "active"
-}, {
+  },
+  {
     "name": "serverless-plugin-dart",
     "description": "Deploy Dart applications to AWS Lambda",
     "githubUrl": "https://github.com/katallaxie/serverless-dart",
     "status": "active"
-}, {
+  },
+  {
     "name": "serverless-scaleway-serverless",
     "description": "This plugin enables support for Scaleway Serverless Functions and Serverless Containers betas within the Serverless Framework",
     "githubUrl": "https://github.com/scaleway/serverless-scaleway-functions",
     "status": "active"
-}, {
+  },
+  {
     "name": "serverless-plugin-iam-checker",
     "description": "Helps automate security controls by preventing overly broad IAM permissions via customizable rules for both actions and resource references. Ships with restrictive defaults and supports custom rule configurations via serverless.yml and environment variables",
     "githubUrl": "https://github.com/manwaring/serverless-plugin-iam-checker",
     "status": "active"
-}, {
+  },
+  {
     "name": "serverless-plugin-layer-manager",
     "description": "Plugin for improved AWS Lambda layer management, including install hooks, export options and improved retain support",
     "githubUrl": "https://github.com/henhal/serverless-plugin-layer-manager",
     "status": "active"
-}, {
+  },
+  {
     "name": "serverless-plugin-lambda-edge",
     "description": "Plugin for Lambda@Edge, just associating your Lambda function with existing CloudFront distribution via AWS SDK",
     "githubUrl": "https://github.com/isudzumi/serverless-plugin-lambda-edge",
     "status": "active"
-}, {
+  },
+  {
     "name": "serverless-export-outputs",
     "description": "A Serverless plugin for exporting AWS stack outputs to a file",
     "githubUrl": "https://github.com/honarpour/serverless-export-outputs",
     "status": "active"
-}, {
+  },
+  {
     "name": "serverless-plugin-apigateway-sqs",
     "description": "Plugin that creates an AWS APIGateway resource to connect to an AWS Simple Queue Service (SQS) without the use of a lambda.",
     "githubUrl": "https://github.com/CodeRecipe-dev/serverless-apigw-sqs-plugin",
     "status": "active"
-}, {
-  "name": "serverless-mongodb-local",
-  "description": "Serverless MongoDB local plugin",
-  "githubUrl": "https://github.com/bealearts/serverless-mongodb-local",
-  "status": "active"
-}, {
+  },
+  {
+    "name": "serverless-mongodb-local",
+    "description": "Serverless MongoDB local plugin",
+    "githubUrl": "https://github.com/bealearts/serverless-mongodb-local",
+    "status": "active"
+  },
+  {
     "name": "serverless-plugin-utils",
     "description": "A collection of serverless framework utilities",
     "githubUrl": "https://github.com/icarus-sullivan/serverless-plugin-utils",
     "status": "active"
-}, {
+  },
+  {
     "name": "serverless-layers",
     "description": "How to reduce drastically lambda size",
     "githubUrl": "https://github.com/agutoli/serverless-layers",
     "status": "active"
-}, {
+  },
+  {
     "name": "mfa-serverless-plugin",
     "description": "A simple plugin for deployment accounts with MFA",
     "githubUrl": "https://github.com/alikian/mfa-serverless-plugin",
     "status": "active"
-}, {
+  },
+  {
     "name": "serverless-ini-env",
     "description": "Nice Serverless plugin to setup environment variables with ini file",
     "githubUrl": "https://github.com/agutoli/serverless-ini-env",
     "status": "active"
-}, {
+  },
+  {
     "name": "serverless-websockets-plugin",
     "description": "Websocket support for Serverless Framework on AWS",
     "githubUrl": "https://github.com/serverless/serverless-websockets-plugin",
     "status": "active"
-}, {
+  },
+  {
     "name": "serverless-resource-policy",
     "description": "Creates a whitelist of IP or CIDR addresses using serverless resource policies",
     "githubUrl": "https://github.com/HubSpotWebTeam/serverless-resource-policy",
     "status": "active"
-}, {
+  },
+  {
     "name": "serverless-plugin-vault-v2",
     "description": "Simplify integration between serverless and vault to storage environments variables",
     "githubUrl": "https://github.com/eliasjcjunior/serverless-plugin-vault-v2",
     "status": "active"
-}, {
+  },
+  {
     "name": "serverless-plugin-powertools",
     "description": "Serverless plugin adding several variable tools, resolvers, and commands",
     "githubUrl": "https://github.com/whardier/serverless-plugin-powertools",
     "status": "active"
-}, {
+  },
+  {
     "name": "serverless-justauthenticateme-plugin",
     "description": "Use JustAuthenticateMe to easily authenticate users before hitting your lambdas",
     "githubUrl": "https://github.com/CoalesceSoftware/serverless-justauthenticateme-plugin",
     "status": "active"
-}, {
+  },
+  {
     "name": "serverless-openapi-plugin",
     "description": "Serverless plugin to generate serverless API architecture from OpenAPI definition.",
     "githubUrl": "https://github.com/jaumard/serverless-openapi-plugin",
     "status": "active"
-}, {
+  },
+  {
     "name": "serverless-dotenv-plugin",
     "description": "Preload environment variables from `.env` into serverless.",
     "githubUrl": "https://github.com/infrontlabs/serverless-dotenv-plugin",
     "status": "active"
-}, {
+  },
+  {
     "name": "serverless-disable-request-validators",
     "description": "Serverless v2/v3 plugin to disable API Gateway request validators.",
     "githubUrl": "https://github.com/jweyrich/serverless-disable-request-validators",
     "status": "active"
-}, {
+  },
+  {
     "name": "serverless-default-aws-resource-attributes",
     "description": "Set default attributes a given CloudFormation resource should have based on type.",
     "githubUrl": "https://github.com/neverendingqs/serverless-default-aws-resource-attributes",
     "status": "active"
-}, {
+  },
+  {
     "name": "serverless-stack-policy-by-resource-type",
     "description": "Serverless Framework plugin for automatically populating CloudFormation stack policy statements by resource type.",
     "githubUrl": "https://github.com/neverendingqs/serverless-stack-policy-by-resource-type",
     "status": "active"
-}, {
+  },
+  {
     "name": "serverless-print-resolved-plugin",
     "description": "Generate a copy of serverless.yml with all variables resolved.",
     "githubUrl": "https://github.com/neverendingqs/serverless-print-resolved-plugin",
     "status": "active"
-}, {
+  },
+  {
     "name": "serverless-discovery-plugin",
     "description": "A serverless plugin to register AWS micro-service endpoints with a discovery service at serverless deploy or serverless remove time.",
     "githubUrl": "https://github.com/aregier/serverless-discovery-plugin",
     "status": "active"
-}, {
+  },
+  {
     "name": "fullstack-serverless",
     "description": "A Serverless plugin to create an AWS CloudFront distribution that serves static web content from S3 and routes API traffic to API Gateway.",
     "githubUrl": "https://github.com/MadSkills-io/fullstack-serverless",
     "status": "active"
-}, {
+  },
+  {
     "name": "serverless-finch",
     "description": "A Serverless plugin to deploy static website assets to AWS S3.",
     "githubUrl": "https://github.com/fernando-mc/serverless-finch",
     "status": "active"
-}, {
+  },
+  {
     "name": "serverless-appsync-plugin",
     "description": "Serverless Plugin to deploy AppSync GraphQL API",
     "githubUrl": "https://github.com/sid88in/serverless-appsync-plugin",
     "status": "active"
-}, {
+  },
+  {
     "name": "serverless-appsync-simulator",
     "description": "Offline support for serverless-appsync-plugin",
     "githubUrl": "https://github.com/bboure/serverless-appsync-simulator",
     "status": "active"
-}, {
+  },
+  {
     "name": "serverless-remote-json-envs",
     "description": "Allows to use plain JSON files in remote locations being parsed as environment variables in lambda",
     "githubUrl": "https://github.com/juancarestre/serverless-remote-json-envs",
     "status": "active"
-}, {
+  },
+  {
     "name": "serverless-plugin-tag-cloud-watch-logs",
     "description": "Small serverless plugin providing a way to add tags to CloudWatch resources",
     "githubUrl": "https://github.com/pretty-fun-therapy/serverless-plugin-tag-cloud-watch-logs",
     "status": "active"
-}, {
+  },
+  {
     "name": "serverless-appsync-offline",
     "description": "Serverless Plugin to run AWS AppSync GraphQL API localy with dynamoDB and lambda resolvers",
     "githubUrl": "https://github.com/aheissenberger/serverless-appsync-offline",
     "status": "active"
-}, {
+  },
+  {
     "name": "aws-amplify-serverless-plugin",
     "description": "Generate client-side configuration files for the AWS Amplify library based on your deployed Serverless backend",
     "githubUrl": "https://github.com/awslabs/aws-amplify-serverless-plugin",
     "status": "active"
-}, {
+  },
+  {
     "name": "serverless-amplify-auth",
     "description": "Update Policy for Amplify's Auth Role and Unauth Role",
     "githubUrl": "https://github.com/nikaera/serverless-amplify-auth",
     "status": "active"
-}, {
+  },
+  {
     "name": "serverless-cloudformation-parameter-setter",
     "description": "Set CloudFormation parameters when deploying.",
     "githubUrl": "https://github.com/trek10inc/serverless-cloudformation-parameter-setter",
     "status": "active"
-}, {
+  },
+  {
     "name": "serverless-alexa-skills",
     "description": "Manage your Alexa Skills with Serverless Framework.",
     "githubUrl": "https://github.com/marcy-terui/serverless-alexa-skills",
     "status": "active"
-}, {
+  },
+  {
     "name": "serverless-plugin-chrome",
     "description": "Plugin which bundles and ensures that Headless Chrome/Chromium is running when your AWS Lambda function handler is invoked.",
     "githubUrl": "https://github.com/adieuadieu/serverless-chrome/tree/master/packages/serverless-plugin",
     "status": "active"
-}, {
+  },
+  {
     "name": "serverless-ssm-fetch",
     "description": "Sets \"AWS Systems Manager Parameter Store (SSM)\" parameters into functions' environment variables.",
     "githubUrl": "https://github.com/gozup/serverless-ssm-fetch",
     "status": "active"
-}, {
+  },
+  {
     "name": "serverless-custom-packaging-plugin",
     "description": "Plugin to package your sourcecode using a custom target path inside the zip.",
     "githubUrl": "https://github.com/hypoport/serverless-custom-packaging-plugin",
     "status": "active"
-}, {
+  },
+  {
     "name": "kumologica-serverless-plugin",
     "description": "Plugin to package and deploy Kumologica flow into AWS",
     "githubUrl": "https://github.com/KumologicaHQ/kumologica-serverless-plugin"
-}, {
+  },
+  {
     "name": "serverless-apigw-binary",
     "description": "Plugin to enable binary support in AWS API Gateway.",
     "githubUrl": "https://github.com/maciejtreder/serverless-apigw-binary",
     "status": "active"
-}, {
+  },
+  {
     "name": "serverless-certificate-creator",
     "description": "This serverless plugin creates certificates that you need for your custom domains in API Gateway.",
     "githubUrl": "https://github.com/schwamster/serverless-certificate-creator",
     "status": "active"
-}, {
+  },
+  {
     "name": "serverless-apigator",
     "description": "This serverless plugin enables you to write AWS lambda with typescript using Microgamma",
     "githubUrl": "https://github.com/microgamma/microgamma",
     "status": "active"
-}, {
+  },
+  {
     "name": "serverless-plugin-1password",
     "description": "Serverless interface to 1Password data via the 1Password CLI",
     "githubUrl": "https://github.com/kandsten/serverless-plugin-1password",
     "status": "active"
-}, {
+  },
+  {
     "name": "serverless-log-filter-subscription",
     "description": "This serverless plugin creates log filter subscription for all lambda functions configured in your projects serverless.yml",
     "githubUrl": "https://github.com/schwamster/serverless-log-filter-subscription",
     "status": "active"
-}, {
+  },
+  {
     "name": "serverless-domain-manager",
     "description": "Serverless plugin for managing custom domains with API Gateways.",
     "githubUrl": "https://github.com/amplify-education/serverless-domain-manager",
     "status": "active"
-}, {
+  },
+  {
     "name": "serverless-log-forwarding",
     "description": "Serverless plugin for forwarding CloudWatch logs to another Lambda function.",
     "githubUrl": "https://github.com/amplify-education/serverless-log-forwarding",
     "status": "active"
-}, {
+  },
+  {
     "name": "serverless-event-body-option",
     "description": "Serverless plugin that provides the extra CLI option for the invoke command to support passing the HTTP body data.",
     "githubUrl": "https://github.com/jubel-han/serverless-event-body-option",
     "status": "active"
-}, {
+  },
+  {
     "name": "serverless-plugin-external-sns-events",
     "description": "Add ability for functions to use existing or external SNS topics as an event source",
     "githubUrl": "https://github.com/silvermine/serverless-plugin-external-sns-events",
     "status": "active"
-}, {
+  },
+  {
     "name": "serverless-plugin-write-env-vars",
     "description": "Write environment variables out to a file that is compatible with dotenv",
     "githubUrl": "https://github.com/silvermine/serverless-plugin-write-env-vars",
     "status": "active"
-}, {
+  },
+  {
     "name": "serverless-alexa-plugin",
     "description": "Serverless plugin to support Alexa Lambda events",
     "githubUrl": "https://github.com/rajington/serverless-alexa-plugin",
     "status": "active"
-}, {
+  },
+  {
     "name": "serverless-build-plugin",
     "description": "A Node.js focused build plugin for serverless.",
     "githubUrl": "https://github.com/nfour/serverless-build-plugin",
     "status": "active"
-}, {
+  },
+  {
     "name": "serverless-resources-env",
     "description": "After Deploy, this plugin fetches cloudformation resource identifiers and sets them on AWS lambdas, and creates local .<state>-env file",
     "githubUrl": "https://github.com/rurri/serverless-resources-env",
     "status": "active"
-}, {
+  },
+  {
     "name": "serverless-event-constant-inputs",
     "description": "Allows you to add constant inputs to events in Serverless 1.0. For more info see [constant values in Cloudwatch](https://aws.amazon.com/blogs/compute/simply-serverless-use-constant-values-in-cloudwatch-event-triggered-lambda-functions/)",
     "githubUrl": "https://github.com/dittto/serverless-event-constant-inputs",
     "status": "active"
-}, {
+  },
+  {
     "name": "serverless-kms-secrets",
     "description": "Allows to easily encrypt and decrypt secrets using KMS from the serverless CLI",
     "githubUrl": "https://github.com/SC5/serverless-kms-secrets",
     "status": "active"
-}, {
+  },
+  {
     "name": "serverless-openapi-integration-helper",
     "description": "Provides functionality to merge stage-dependent x-amazon-apigateway integrations into openApiSpecification files ",
     "githubUrl": "https://github.com/yndlingsfar/serverless-openapi-integration-helper",
     "status": "active"
-}, {
+  },
+  {
     "name": "serverless-plugin-stack-outputs",
     "description": "Displays stack outputs for your serverless stacks when `sls info` is ran",
     "githubUrl": "https://github.com/svdgraaf/serverless-plugin-stack-outputs",
     "status": "active"
-}, {
+  },
+  {
     "name": "serverless-plugin-stage-variables",
     "description": "Add stage variables for Serverless 1.x to ApiGateway, so you can use variables in your Lambda's",
     "githubUrl": "https://github.com/svdgraaf/serverless-plugin-stage-variables",
     "status": "active"
-}, {
+  },
+  {
     "name": "serverless-plugin-cloudwatch-sumologic",
     "description": "Plugin which auto-subscribes a log delivery lambda function to lambda log groups created by serverless",
     "githubUrl": "https://github.com/ACloudGuru/serverless-plugin-cloudwatch-sumologic",
     "status": "active"
-}, {
+  },
+  {
     "name": "serverless-plugin-aws-alerts",
     "description": "A Serverless plugin to easily add CloudWatch alarms to functions",
     "githubUrl": "https://github.com/ACloudGuru/serverless-plugin-aws-alerts",
     "status": "active"
-}, {
+  },
+  {
     "name": "serverless-plugin-package-dotenv-file",
     "description": "A Serverless plugin to copy a .env file into the serverless package",
     "githubUrl": "https://github.com/ACloudGuru/serverless-plugin-package-dotenv-file",
     "status": "active"
-}, {
+  },
+  {
     "name": "serverless-command-line-event-args",
     "description": "This module is Serverless Framework plugin. Event JSON passes to your Lambda function in commandline.",
     "githubUrl": "https://github.com/horike37/serverless-command-line-event-args",
     "status": "active"
-}, {
+  },
+  {
     "name": "serverless-dynamodb-client",
     "description": "This Serverless 0.5.x plugin help you to call AWS Dynamodb SDK without switching between different dynamodb instances, whether you work with Dynamodb local or online in AWS.",
     "githubUrl": "https://github.com/99xt/serverless-dynamodb-client",
     "status": "active"
-}, {
+  },
+  {
     "name": "serverless-dynamodb-local",
     "description": "Serverless Dynamodb Local Plugin - Allows to run dynamodb locally for serverless",
     "githubUrl": "https://github.com/99xt/serverless-dynamodb-local",
     "status": "active"
-}, {
+  },
+  {
     "name": "serverless-dynamodb-fixtures",
     "description": "Serverless Dynamodb Fixtures - Allows to load data on DynamoDB tables",
     "githubUrl": "https://github.com/chechu/serverless-dynamodb-fixtures",
     "status": "active"
-}, {
+  },
+  {
     "name": "serverless-dynamo-stream-plugin",
     "description": "Creates and connects DynamoDB streams for pre-existing tables with AWS Lambdas using Serverless.",
     "githubUrl": "https://github.com/commandeer/open/tree/development/serverless-dynamo-stream-plugin",
     "status": "active"
-}, {
+  },
+  {
     "name": "dynamo-data-transform",
     "description": "Dynamo Data Transform is an easy to use data transformation tool for DynamoDB.",
     "githubUrl": "https://github.com/jitsecurity/dynamo-data-transform",
     "status": "active"
-}, {
+  },
+  {
     "name": "serverless-offline",
     "description": "Emulate AWS λ and API Gateway locally when developing your Serverless project",
     "githubUrl": "https://github.com/dherault/serverless-offline",
     "status": "active"
-}, {
+  },
+  {
     "name": "serverless-offline-local-authorizers-plugin",
     "description": "Serverless plugin for adding and mocking local authorizers when developing locally with serverless-offline.",
     "githubUrl": "https://github.com/nlang/serverless-offline-local-authorizers-plugin",
     "status": "active"
-}, {
+  },
+  {
     "name": "serverless-offline-ssm",
     "description": "Read SSM parameters from a .env file instead of AWS",
     "githubUrl": "https://github.com/janders223/serverless-offline-ssm",
     "status": "active"
-}, {
+  },
+  {
     "name": "serverless-offline-direct-lambda",
     "description": "Allow offline direct lambda-to-lambda interactions by exposing lambdas with no API Gateway event via HTTP.",
     "githubUrl": "https://github.com/civicteam/serverless-offline-direct-lambda",
     "status": "active"
-}, {
+  },
+  {
     "name": "serverless-offline-ses-v2",
     "description": "Serverless plugin to run a local version of Amazon Simple Email Service (SES) supporting the V1 and V2 SendEmail and SendRawEmail APIs",
     "githubUrl": "https://github.com/domdomegg/serverless-offline-ses-v2",
     "status": "active"
-}, {
-	"name": "serverless-offline-edge-lambda",
+  },
+  {
+    "name": "serverless-offline-edge-lambda",
     "description": "A plugin for the Serverless Framework that simulates the behavior of AWS CloudFront Edge Lambdas while developing offline",
     "githubUrl": "https://github.com/evolv-ai/serverless-offline-edge-lambda",
     "status": "active"
-}, {
+  },
+  {
     "name": "serverless-plugin-simulate",
     "description": "Simulate AWS Lambda and API Gateway locally using Docker",
     "githubUrl": "https://github.com/gertjvr/serverless-plugin-simulate",
     "status": "active"
-}, {
+  },
+  {
     "name": "serverless-plugin-optimize",
     "description": "Bundle with Browserify, transpile with Babel to ES5 and minify with Uglify your Serverless functions.",
     "githubUrl": "https://github.com/FidelLimited/serverless-plugin-optimize",
     "status": "active"
-}, {
+  },
+  {
     "name": "serverless-plugin-select",
     "description": "Select which functions are to be deployed based on region and stage.",
     "githubUrl": "https://github.com/FidelLimited/serverless-plugin-select",
     "status": "active"
-}, {
+  },
+  {
     "name": "serverless-plugin-warmup",
     "description": "Keep your lambdas warm during Winter.",
     "githubUrl": "https://github.com/juanjoDiaz/serverless-plugin-warmup",
     "status": "active"
-}, {
+  },
+  {
     "name": "serverless-plugin-aws-contributor-insights",
     "description": "Support of AWS CloudWatch Contributor Insights",
     "githubUrl": "https://github.com/kangcifong/serverless-plugin-aws-contributor-insights",
     "status": "active"
-}, {
+  },
+  {
     "name": "serverless-plugin-browserify",
     "description": "Speed up your node based lambda's",
     "githubUrl": "https://github.com/doapp-ryanp/serverless-plugin-browserify",
     "status": "inactive"
-}, {
+  },
+  {
     "name": "serverless-plugin-datadog",
     "description": "Monitoring, tracing, and real-time metrics for your Lambda functions",
     "githubUrl": "https://github.com/DataDog/serverless-plugin-datadog",
     "status": "active"
-}, {
+  },
+  {
     "name": "serverless-plugin-diff",
     "description": "Compares your local AWS CloudFormation templates against deployed ones.",
     "githubUrl": "https://github.com/nicka/serverless-plugin-diff",
     "status": "active"
-}, {
+  },
+  {
     "name": "serverless-run-function-plugin",
     "description": "Run serverless function locally",
     "githubUrl": "https://github.com/lithin/serverless-run-function-plugin",
     "status": "active"
-}, {
+  },
+  {
     "name": "serverless-scriptable-plugin",
     "description": "Customize Serverless behavior without writing a plugin.",
     "githubUrl": "https://github.com/weixu365/serverless-scriptable-plugin",
     "status": "active"
-}, {
+  },
+  {
     "name": "serverless-subscription-filter",
     "description": "Serverless plugin to register subscription filter for Lambda logs. Register and pipe the logs of one lambda to another to process.",
     "githubUrl": "https://github.com/blackevil245/serverless-subscription-filter",
     "status": "active"
-}, {
+  },
+  {
     "name": "serverless-webpack",
     "description": "Serverless plugin to bundle your lambdas with Webpack",
     "githubUrl": "https://github.com/serverless-heaven/serverless-webpack",
     "status": "active"
-}, {
+  },
+  {
     "name": "serverless-esbuild",
     "description": "Serverless plugin to bundle JavaScript and TypeScript lambdas with esbuild - an extremely fast bundler and minifier",
     "githubUrl": "https://github.com/floydspace/serverless-esbuild",
     "status": "active"
-}, {
+  },
+  {
     "name": "serverless-wsgi",
     "description": "Serverless plugin to deploy WSGI applications (Flask/Django/Pyramid etc.) and bundle Python packages",
     "githubUrl": "https://github.com/logandk/serverless-wsgi",
     "status": "active"
-}, {
+  },
+  {
     "name": "serverless-crypt",
     "description": "Securing the secrets on Serverless Framework by AWS KMS encryption.",
     "githubUrl": "https://github.com/marcy-terui/serverless-crypt",
     "status": "active"
-}, {
+  },
+  {
     "name": "serverless-plugin-multiple-responses",
     "description": "Enable multiple content-types for Response template ",
     "githubUrl": "https://github.com/silvermine/serverless-plugin-multiple-responses",
     "status": "active"
-}, {
+  },
+  {
     "name": "serverless-plugin-dot-template",
     "description": "Generates output files based on Serverless variables and doT templates",
     "githubUrl": "https://github.com/kandsten/serverless-plugin-dot-template",
     "status": "active"
-}, {
+  },
+  {
     "name": "serverless-plugin-include-dependencies",
     "description": "This is a Serverless plugin that should make your deployed functions smaller.",
     "githubUrl": "https://github.com/dougmoscrop/serverless-plugin-include-dependencies",
     "status": "active"
-}, {
+  },
+  {
     "name": "serverless-mocha-plugin",
     "description": "A Serverless Plugin for the Serverless Framework which adds support for test-driven development using Mocha",
     "githubUrl": "https://github.com/SC5/serverless-mocha-plugin",
     "status": "active"
-}, {
+  },
+  {
     "name": "serverless-modular",
     "description": "Helps you deploy and manage multiple features with single root serverless file",
     "githubUrl": "https://github.com/aa2kb/serverless-modular",
     "status": "active"
-}, {
+  },
+  {
     "name": "serverless-jest-plugin",
     "description": "A Serverless Plugin for the Serverless Framework which adds support for test-driven development using Jest",
     "githubUrl": "https://github.com/SC5/serverless-jest-plugin",
     "status": "active"
-}, {
+  },
+  {
     "name": "serverless-plugin-cfauthorizer",
     "description": "This plugin allows you to define your own API Gateway Authorizers as the Serverless CloudFormation resources and apply them to HTTP endpoints.",
     "githubUrl": "https://github.com/SC5/serverless-plugin-cfauthorizer",
     "status": "active"
-}, {
+  },
+  {
     "name": "serverless-cloudformation-changesets",
     "description": "Natively deploy to CloudFormation via Change sets, instead of directly. Allowing you to queue changes, and safely require escalated roles for final deployment.",
     "githubUrl": "https://github.com/trek10inc/serverless-cloudformation-changesets",
     "status": "active"
-}, {
+  },
+  {
     "name": "raml-serverless",
     "description": "Serverless plugin to work with RAML API spec documents",
     "githubUrl": "https://github.com/andrewcurioso/raml-serverless",
     "status": "active"
-}, {
+  },
+  {
     "name": "serverless-python-requirements",
     "description": "Serverless plugin to bundle Python packages",
     "githubUrl": "https://github.com/UnitedIncome/serverless-python-requirements",
     "status": "active"
-}, {
+  },
+  {
     "name": "serverless-pydeps",
     "description": "Serverless plugin to quickly automate Python dependencies",
     "githubUrl": "https://github.com/CloudSnorkel/serverless-pydeps",
     "status": "active"
-}, {
+  },
+  {
     "name": "serverless-ruby-layer",
     "description": "A Serverless Plugin to auto deploy gems to AWS Layer using Gemfile",
     "githubUrl": "https://github.com/navarasu/serverless-ruby-layer",
     "status": "active"
-}, {
+  },
+  {
     "name": "serverless-multi-dotnet",
     "description": "A serverless plugin to pack C# lambdas functions that are spread to multiple CS projects.",
     "githubUrl": "https://github.com/tsibelman/serverless-multi-dotnet",
     "status": "active"
-},{
+  },
+  {
     "name": "serverless-dotnet",
     "description": "A serverless plugin to run 'dotnet' commands as part of the deploy process",
     "githubUrl": "https://github.com/fruffin/serverless-dotnet",
     "status": "active"
-}, {
+  },
+  {
     "name": "serverless-enable-api-logs",
     "description": "Enables Coudwatch logging for API Gateway events",
     "githubUrl": "https://github.com/paulSambolin/serverless-enable-api-logs",
     "status": "active"
-}, {
+  },
+  {
     "name": "serverless-python-individually",
     "description": "A serverless framework plugin to install multiple lambda functions written in python",
     "githubUrl": "https://github.com/cfchou/serverless-python-individually",
     "status": "active"
-}, {
+  },
+  {
     "name": "serverless-plugin-subscription-filter",
     "description": "A serverless plugin to register AWS CloudWatchLogs subscription filter",
     "githubUrl": "https://github.com/tsub/serverless-plugin-subscription-filter",
     "status": "active"
-}, {
+  },
+  {
     "name": "serverless-step-functions",
     "description": "AWS Step Functions plugin for Serverless Framework",
     "githubUrl": "https://github.com/serverless-operations/serverless-step-functions",
     "status": "active"
-}, {
+  },
+  {
     "name": "serverless-lambda-layer-packager",
     "description": "A Serverless plugin that allows you to maintain your normal project structure when developing Lambda Layers.",
     "githubUrl": "https://github.com/bramhoven/serverless-lambda-layer-packager",
     "status": "active"
-}, {
+  },
+  {
     "name": "serverless-apigateway-service-proxy",
     "description": "This Serverless Framewrok plugin supports the AWS service proxy integration feature of API Gateway.",
     "githubUrl": "https://github.com/horike37/serverless-apigateway-service-proxy",
     "status": "active"
-}, {
+  },
+  {
     "name": "serverless-package-customizer",
     "description": "This allows you to customize packaging system of the Serverless Framework from a command line.",
     "githubUrl": "https://github.com/horike37/serverless-package-customizer",
     "status": "active"
-}, {
+  },
+  {
     "name": "serverless-package-location-customizer",
     "description": "A serverless plugin to allow custom S3Bucket and S3Key path when packaging Lambda Functions and Layers.",
     "githubUrl": "https://github.com/cipri-p/serverless-package-location-customizer",
     "status": "active"
-}, {
+  },
+  {
     "name": "serverless-plugin-scripts",
     "description": "Add scripting capabilities to the Serverless Framework",
     "githubUrl": "https://github.com/mvila/serverless-plugin-scripts",
     "status": "active"
-}, {
+  },
+  {
     "name": "serverless-plugin-bind-deployment-id",
     "description": "A Serverless plugin to bind the randomly generated deployment resource to your custom resources",
     "githubUrl": "https://github.com/jacob-meacham/serverless-plugin-bind-deployment-id",
     "status": "active"
-}, {
+  },
+  {
     "name": "serverless-plugin-git-variables",
     "description": "A Serverless plugin to expose git variables (branch name, HEAD description, full commit hash) to your serverless services",
     "githubUrl": "https://github.com/jacob-meacham/serverless-plugin-git-variables",
     "status": "active"
-}, {
+  },
+  {
     "name": "serverless-plugin-graphiql",
     "description": "A Serverless plugin to run a local http server for graphiql and your graphql handler",
     "githubUrl": "https://github.com/bencooling/serverless-plugin-graphiql",
     "status": "active"
-}, {
+  },
+  {
     "name": "serverless-coffeescript",
     "description": "A Serverless plugin to compile your CoffeeScript into JavaScript at deployment",
     "githubUrl": "https://github.com/duanefields/serverless-coffeescript",
     "status": "active"
-}, {
+  },
+  {
     "name": "serverless-plugin-lambda-dead-letter",
     "description": "A Serverless plugin that can configure a lambda with a dead letter queue or topic",
     "githubUrl": "https://github.com/gmetzker/serverless-plugin-lambda-dead-letter",
     "status": "active"
-}, {
+  },
+  {
     "name": "serverless-plugin-encode-env-var-objects",
     "description": "Serverless plugin to encode any environment variable objects.",
     "githubUrl": "https://github.com/yonomi/serverless-plugin-encode-env-var-objects",
     "status": "active"
-}, {
+  },
+  {
     "name": "serverless-dir-config-plugin",
     "description": "EXPERIMENTAL - Serverless plugin to load function and resource definitions from a directory.",
     "githubUrl": "https://github.com/economysizegeek/serverless-dir-config-plugin",
     "status": "active"
-}, {
+  },
+  {
     "name": "serverless-cljs-plugin",
     "description": "Enables Clojurescript as an implementation language for Lambda handlers",
     "githubUrl": "https://github.com/nervous-systems/serverless-cljs-plugin",
     "status": "active"
-}, {
+  },
+  {
     "name": "serverless-apigateway-log-retention",
     "description": "Control the retention of your AWS ApiGateway access logs and execution logs.",
     "githubUrl": "https://github.com/dvla/serverless-apigateway-log-retention",
     "status": "active"
-}, {
+  },
+  {
     "name": "serverless-prune-plugin",
     "description": "Deletes old versions of functions from AWS, preserving recent and aliased versions",
     "githubUrl": "https://github.com/claygregory/serverless-prune-plugin",
     "status": "active"
-}, {
+  },
+  {
     "name": "@unly/serverless-env-copy-plugin",
     "description": "Fetch environment variables and write it to a .env file - Maintained fork from https://github.com/Jimdo/serverless-dotenv",
     "githubUrl": "https://github.com/UnlyEd/serverless-env-copy-plugin",
     "status": "active"
-}, {
+  },
+  {
     "name": "@unly/serverless-plugin-dynamodb-backups",
     "description": "Configure automated DynamoDB \"On-Demand\" backups and manage backups lifecycle, powered by AWS Lambda",
     "githubUrl": "https://github.com/UnlyEd/serverless-plugin-dynamodb-backups",
     "status": "active"
-}, {
+  },
+  {
     "name": "serverless-convention",
     "description": "Dynamically import resources by defining a convention, split up your yml",
     "githubUrl": "https://github.com/LeoPlatform/serverless-convention",
     "status": "active"
-}, {
+  },
+  {
     "name": "serverless-openapi-documenter",
     "description": "A plugin that creates a valid OpenAPI 3.0.X json or yaml schema as well as being able to output a Postman Collection v2 in json.",
     "githubUrl": "https://github.com/JaredCE/serverless-openapi-documenter",
     "status": "active"
-}, {
+  },
+  {
     "name": "serverless-offline-scheduler",
     "description": "Runs scheduled functions offline while integrating with serverless-offline",
     "githubUrl": "https://github.com/ajmath/serverless-offline-scheduler",
     "status": "active"
-}, {
+  },
+  {
     "name": "serverless-aws-alias",
     "description": "This plugin enables use of AWS aliases on Lambda functions.",
     "githubUrl": "https://github.com/serverless-heaven/serverless-aws-alias",
     "status": "active"
-}, {
+  },
+  {
     "name": "serverless-plugin-webpack",
     "description": "A serverless plugin to automatically bundle your functions individually with webpack",
     "githubUrl": "https://github.com/goldwasserexchange/serverless-plugin-webpack",
     "status": "active"
-}, {
+  },
+  {
     "name": "serverless-secret-baker",
     "description": "A Serverless Framework Plugin for secure, performant, and deterministic secret management.",
     "githubUrl": "https://github.com/vacasaoss/serverless-secret-baker",
     "status": "active"
-}, {
+  },
+  {
     "name": "serverless-sqs-fifo",
     "description": "A serverless plugin to handle creation of sqs fifo queue's in aws (stop-gap)",
     "githubUrl": "https://github.com/vortarian/serverless-sqs-fifo",
     "status": "active"
-}, {
+  },
+  {
     "name": "serverless-sqs-alarms-plugin",
     "description": "Wrapper to setup CloudWatch Alarms on SQS queue length",
     "githubUrl": "https://github.com/sbstjn/serverless-sqs-alarms-plugin",
     "status": "inactive"
-}, {
+  },
+  {
     "name": "serverless-dotenv",
     "description": "Fetch environment variables and write it to a .env file",
     "githubUrl": "https://github.com/Jimdo/serverless-dotenv",
     "status": "active"
-}, {
+  },
+  {
     "name": "serverless-haskell",
     "description": "Deploying Haskell applications to AWS Lambda with Serverless",
     "githubUrl": "https://github.com/seek-oss/serverless-haskell",
     "status": "active"
-}, {
+  },
+  {
     "name": "serverless-hooks-plugin",
     "description": "Run arbitrary commands on any lifecycle event in serverless",
     "githubUrl": "https://github.com/uswitch/serverless-hooks-plugin",
     "status": "active"
-}, {
+  },
+  {
     "name": "serverless-offline-watcher",
     "description": "Run arbitrary commands when files are changed while running serverless-offline",
     "githubUrl": "https://github.com/domdomegg/serverless-offline-watcher",
     "status": "active"
-}, {
+  },
+  {
     "name": "serverless-dynalite",
     "description": "Run dynalite locally (no JVM, all JS) to simulate DynamoDB. Watch serverless.yml for table config updates.",
     "githubUrl": "https://github.com/sdd/serverless-dynalite",
     "status": "active"
-}, {
+  },
+  {
     "name": "serverless-apig-s3",
     "description": "Serve static front-end content from S3 via the API Gateway and deploy client bundle to S3.",
     "githubUrl": "https://github.com/sdd/serverless-apig-s3",
     "status": "active"
-}, {
+  },
+  {
     "name": "serverless-plugin-typescript",
     "description": "Serverless plugin for zero-config Typescript support.",
     "githubUrl": "https://github.com/graphcool/serverless-plugin-typescript",
     "status": "active"
-}, {
+  },
+  {
     "name": "serverless-parameters",
     "description": "Add parameters to the generated cloudformation templates",
     "githubUrl": "https://github.com/svdgraaf/serverless-parameters",
     "status": "active"
-}, {
+  },
+  {
     "name": "serverless-git-commit-tracker",
     "description": "Generates a version tracking file for web or API deployment containing the latest git commit version number, deployment stage, and date",
     "githubUrl": "https://github.com/optimator999/serverless-git-commit-tracker",
     "status": "active"
-},{
+  },
+  {
     "name": "serverless-plugin-epsagon",
     "description": "Distributed tracing that helps you monitor and troubleshoot your serverless applications.",
     "githubUrl": "https://github.com/epsagon/serverless-plugin-epsagon",
     "status": "active"
-}, {
+  },
+  {
     "name": "serverless-dynamodb-ttl",
     "description": "Configure DynamoDB TTL in serverless.yml (until CloudFormation supports this).",
     "githubUrl": "https://github.com/Jimdo/serverless-dynamodb-ttl",
     "status": "active"
-}, {
+  },
+  {
     "name": "serverless-api-stage",
     "description": "Serverless API Stage plugin, enables stage variables and logging for AWS API Gateway.",
     "githubUrl": "https://github.com/leftclickben/serverless-api-stage",
     "status": "active"
-},{
+  },
+  {
     "name": "serverless-plugin-lambda-insights",
     "description": "A Serverless Framework Plugin allowing to enable Lambda Insights.",
     "githubUrl": "https://github.com/awslabs/serverless-plugin-lambda-insights",
     "status": "active"
-},
- {
+  },
+  {
     "name": "serverless-export-env",
     "description": "Export environment variables into a .env file with automatic AWS CloudFormation reference resolution.",
     "githubUrl": "https://github.com/arabold/serverless-export-env",
     "status": "active"
-}, {
+  },
+  {
     "name": "serverless-package-python-functions",
     "description": "Packaging Python Lambda functions with only the dependencies/requirements they need.",
     "githubUrl": "https://github.com/ubaniabalogun/serverless-package-python-functions",
     "status": "active"
-}, {
+  },
+  {
     "name": "serverless-plugin-iopipe",
     "description": "See inside your Lambda functions with high fidelity metrics and monitoring.",
     "githubUrl": "https://github.com/iopipe/serverless-plugin-iopipe",
     "status": "active"
-}, {
+  },
+  {
     "name": "serverless-plugin-metric",
     "description": "Creates dynamically AWS metric-filter resources with custom patterns",
     "githubUrl": "https://github.com/alex20465/serverless-plugin-metric",
     "status": "active"
-}, {
+  },
+  {
     "name": "serverless-sam",
     "description": "Exports an AWS SAM template for a service created with the Serverless Framework.",
     "githubUrl": "https://github.com/SAPessi/serverless-sam",
     "status": "active"
-}, {
+  },
+  {
     "name": "serverless-vpc-discovery",
     "description": "Serverless plugin for discovering VPC / Subnet / Security Group configuration by name.",
     "githubUrl": "https://github.com/amplify-education/serverless-vpc-discovery",
     "status": "active"
-}, {
+  },
+  {
     "name": "serverless-kubeless",
     "description": "Serverless plugin for deploying functions to Kubeless.",
     "githubUrl": "https://github.com/serverless/serverless-kubeless",
     "status": "active"
-}, {
+  },
+  {
     "name": "serverless-kubeless-offline",
     "description": "Simulates Kubeless NodeJS runtimes to run/call your functions offline using the Serverless Framework.",
     "githubUrl": "https://github.com/usefulio/serverless-kubeless-offline",
     "status": "active"
-}, {
+  },
+  {
     "name": "serverless-apigwy-binary",
     "description": "Serverless plugin for configuring API Gateway to return binary responses",
     "githubUrl": "https://github.com/ryanmurakami/serverless-apigwy-binary",
     "status": "active"
-}, {
+  },
+  {
     "name": "serverless-plugin-browserifier",
     "description": "Reduce the size and speed up your Node.js based lambda's using browserify.",
     "githubUrl": "https://github.com/digitalmaas/serverless-plugin-browserifier",
     "status": "active"
-}, {
+  },
+  {
     "name": "@digitalmaas/serverless-plugin-sqs-alarms",
     "description": "Simplifies the setup of CloudWatch Alarms to monitor the visible messages in an SQS queue.",
     "githubUrl": "https://github.com/digitalmaas/serverless-plugin-sqs-alarms",
     "status": "active"
-}, {
+  },
+  {
     "name": "serverless-shell",
     "description": "Drop to a runtime shell with all the environment variables set that you'd have in lambda.",
     "githubUrl": "https://github.com/UnitedIncome/serverless-shell",
     "status": "active"
-}, {
+  },
+  {
     "name": "serverless-stack-output",
     "description": "Store output from your AWS CloudFormation Stack in JSON/YAML/TOML files, or to pass it to a JavaScript function for further processing.",
     "githubUrl": "https://github.com/sbstjn/serverless-stack-output",
     "status": "active"
-}, {
+  },
+  {
     "name": "serverless-gulp",
     "description": "A thin task wrapper around @goserverless that allows you to automate build, test and deploy tasks using gulp",
     "githubUrl": "https://github.com/rhythminme/serverless-gulp",
     "status": "active"
-}, {
+  },
+  {
     "name": "serverless-google-cloudfunctions",
     "description": "This plugin enables support for Google Cloud Functions within the Serverless Framework.",
     "githubUrl": "https://github.com/serverless/serverless-google-cloudfunctions",
     "status": "active"
-}, {
+  },
+  {
     "name": "serverless-azure-functions",
     "description": "A Serverless plugin that adds Azure Functions support to the Serverless Framework.",
     "githubUrl": "https://github.com/serverless/serverless-azure-functions",
     "status": "active"
-}, {
+  },
+  {
     "name": "serverless-sentry",
     "description": "Automatic monitoring of memory usage, execution timeouts and forwarding of Lambda errors to Sentry (https://sentry.io).",
     "githubUrl": "https://github.com/arabold/serverless-sentry-plugin",
     "status": "active"
-}, {
+  },
+  {
     "name": "serverless-env-generator",
     "description": "Manage environment variables with YAML and load them with dotenv. Supports variable encryption with KMS, multiple stages and custom profiles.",
     "githubUrl": "https://github.com/DieProduktMacher/serverless-env-generator",
     "status": "active"
-}, {
+  },
+  {
     "name": "@redtea/serverless-env-generator",
     "description": "Manage environment variables with YAML and load them with dotenv. Supports variable encryption with KMS, multiple stages and custom profiles. Maintained fork from https://github.com/DieProduktMacher/serverless-env-generator with more advanced YAML anchors supporting and other.",
     "githubUrl": "https://github.com/org-redtea/serverless-env-generator",
     "status": "active"
-}, {
-  "name": "@agiledigital/serverless-sns-sqs-lambda",
-  "description": "Provide the lambda function with the snsSqs event, the plugin will add the AWS SNS topic and subscription, SQS queue and dead letter queue, and the role need for the lambda.",
-  "githubUrl": "https://github.com/agiledigital/serverless-sns-sqs-lambda",
-  "status": "active"
-}, {
+  },
+  {
+    "name": "@agiledigital/serverless-sns-sqs-lambda",
+    "description": "Provide the lambda function with the snsSqs event, the plugin will add the AWS SNS topic and subscription, SQS queue and dead letter queue, and the role need for the lambda.",
+    "githubUrl": "https://github.com/agiledigital/serverless-sns-sqs-lambda",
+    "status": "active"
+  },
+  {
     "name": "serverless-plugin-embedded-env-in-code",
     "description": "Replace environment variables with static strings before deployment. It’s for Lambda@Edge.",
     "githubUrl": "https://github.com/zaru/serverless-plugin-embedded-env-in-code",
     "status": "active"
-}, {
+  },
+  {
     "name": "serverless-local-dev-server",
     "description": "Speeds up development of Alexa Skills, Chatbots and APIs by exposing your functions as local HTTP endpoints and mapping received events.",
     "githubUrl": "https://github.com/DieProduktMacher/serverless-local-dev-server",
     "status": "active"
-}, {
+  },
+  {
     "name": "serverless-plugin-stack-config",
     "description": "A serverless plugin to manage configurations for a stack across micro-services.",
     "githubUrl": "https://github.com/rawphp/serverless-plugin-stack-config",
     "status": "active"
-}, {
+  },
+  {
     "name": "serverless-plugin-elastic-beanstalk",
     "description": "A serverless plugin to deploy applications to AWS ElasticBeanstalk.",
     "githubUrl": "https://github.com/rawphp/serverless-plugin-elastic-beanstalk",
     "status": "active"
-}, {
+  },
+  {
     "name": "serverless-s3-local",
     "description": "A serverless plugin to run a S3 clone on your local machine",
     "githubUrl": "https://github.com/ar90n/serverless-s3-local",
     "status": "active"
-}, {
+  },
+  {
     "name": "serverless-s3-remover",
     "description": "A serverless plugin to make s3 buckets empty before deleting cloudformation stack when ```sls remove```",
     "githubUrl": "https://github.com/sinofseven/serverless-s3-remover",
     "status": "active"
-}, {
+  },
+  {
     "name": "serverless-dynamodb-autoscaling",
     "description": "Configure Amazon DynamoDB's native Auto Scaling for your table capacities.",
     "githubUrl": "https://github.com/sbstjn/serverless-dynamodb-autoscaling",
     "status": "active"
-}, {
+  },
+  {
     "name": "serverless-plugin-bespoken",
     "description": "Creates a local server and a proxy so you don't have to deploy anytime you want to test your code",
     "githubUrl": "https://github.com/bespoken/serverless-plugin-bespoken",
     "status": "active"
-}, {
+  },
+  {
     "name": "serverless-s3bucket-sync",
     "description": "Sync a local folder with a S3 bucket after sls deploy",
     "githubUrl": "https://github.com/sbstjn/serverless-s3bucket-sync",
     "status": "active"
-}, {
+  },
+  {
     "name": "serverless-s3-sync",
     "description": "A plugin to sync local directories and S3 prefixes for Serverless Framework,",
     "githubUrl": "https://github.com/k1LoW/serverless-s3-sync",
     "status": "active"
-}, {
+  },
+  {
     "name": "serverless-build-client",
     "description": "Build your static website with environment variables defined in serverless.yml",
     "githubUrl": "https://github.com/tgfischer/serverless-build-client",
     "status": "active"
-}, {
+  },
+  {
     "name": "serverless-nested-stack",
     "description": "A plugin to Workaround for Cloudformation 200 resource limit",
     "githubUrl": "https://github.com/jagdish-176/serverless-nested-stack",
     "status": "active"
-}, {
+  },
+  {
     "name": "serverless-plugin-common-excludes",
     "description": "Adds commonly excluded files to package.excludes",
     "githubUrl": "https://github.com/dougmoscrop/serverless-plugin-common-excludes",
     "status": "active"
-}, {
+  },
+  {
     "name": "serverless-plugin-custom-domain",
     "description": "Reliably sets a BasePathMapping to an API Gateway Custom Domain",
     "githubUrl": "https://github.com/dougmoscrop/serverless-plugin-custom-domain",
     "status": "active"
-}, {
+  },
+  {
     "name": "serverless-plugin-split-stacks",
     "description": "Migrate certain resources to nested stacks",
     "githubUrl": "https://github.com/dougmoscrop/serverless-plugin-split-stacks",
     "status": "active"
-}, {
+  },
+  {
     "name": "serverless-plugin-log-subscription",
     "description": "Adds a CloudWatch LogSubscription for functions",
     "githubUrl": "https://github.com/dougmoscrop/serverless-plugin-log-subscription",
     "status": "active"
-}, {
+  },
+  {
     "name": "serverless-cf-vars",
     "description": "Enables use of AWS pseudo functions and Fn::Sub string substitution",
     "githubUrl": "https://gitlab.com/kabo/serverless-cf-vars",
     "status": "active"
-}, {
+  },
+  {
     "name": "serverless-apigateway-plugin",
     "description": "Configure the AWS api gateway: Binary support, Headers and Body template mappings",
     "githubUrl": "https://github.com/GFG/serverless-apigateway-plugin",
     "status": "active"
-}, {
+  },
+  {
     "name": "serverless-plugin-deploy-environment",
     "description": "Plugin to manage deployment environment across stages",
     "githubUrl": "https://github.com/DopplerLabs/serverless-plugin-deploy-environment",
     "status": "active"
-}, {
+  },
+  {
     "name": "serverless-import-config-plugin",
     "description": "Import YAML files in serverless.yaml config file",
     "githubUrl": "https://github.com/KrysKruk/serverless-import-config-plugin",
     "status": "active"
-}, {
+  },
+  {
     "name": "serverless-plugin-aws-resolvers",
     "description": "Resolves variables from ESS, RDS, or Kinesis for serverless services",
     "githubUrl": "https://github.com/DopplerLabs/serverless-plugin-aws-resolvers",
     "status": "active"
-}, {
+  },
+  {
     "name": "serverless-plugin-offline-kinesis-events",
     "description": "Plugin that works with serverless-offline to allow offline testing of serverless functions that are triggered by Kinesis events.",
     "githubUrl": "https://github.com/DopplerLabs/serverless-plugin-offline-kinesis-events",
     "status": "active"
-}, {
+  },
+  {
     "name": "serverless-micro",
     "description": "Plugin to help manage multiple micro services under one main service.",
     "githubUrl": "https://github.com/barstoolsports/serverless-micro",
     "status": "active"
-}, {
+  },
+  {
     "name": "serverless-api-cloudfront",
     "description": "Plugin that adds CloudFront distribution in front of your API Gateway for custom domain, CDN caching and access log.",
     "githubUrl": "https://github.com/Droplr/serverless-api-cloudfront",
     "status": "active"
-}, {
+  },
+  {
     "name": "serverless-offline-sns",
     "description": "Serverless plugin to run a local SNS server and call serverless SNS handlers with events notifications.",
     "githubUrl": "https://github.com/mj1618/serverless-offline-sns",
     "status": "active"
-}, {
+  },
+  {
     "name": "serverless-stage-manager",
     "description": "Super simple Serverless plugin for validating stage names before deployment",
     "githubUrl": "https://github.com/jeremydaly/serverless-stage-manager",
     "status": "active"
-}, {
+  },
+  {
     "name": "serverless-lift",
     "description": "Deploy high-level components such as static websites, buckets, queues, webhooks...",
     "githubUrl": "https://github.com/getlift/lift",
     "status": "active"
-}, {
+  },
+  {
     "name": "serverless-spa",
     "description": "Serverless plugin to deploy your website to AWS S3 using Webpack to bundle it.",
     "githubUrl": "https://github.com/gilmarsquinelato/serverless-spa",
     "status": "active"
-}, {
+  },
+  {
     "name": "serverless-aws-nested-stacks",
     "description": "Yet another AWS nested stack plugin!",
     "githubUrl": "https://github.com/concon121/serverless-plugin-nested-stacks",
     "status": "active"
-}, {
+  },
+  {
     "name": "serverless-aws-resource-names",
     "description": "Serverless plugin to alter the default naming conventions for sls resources via a simple mapping file.",
     "githubUrl": "https://github.com/concon121/serverless-plugin-aws-resource-names",
     "status": "active"
-}, {
+  },
+  {
     "name": "serverless-attach-managed-policy",
     "description": "A Serverless plugin to automatically attach an AWS Managed IAM Policy (or Policies) to all IAM Roles created by the Service.",
     "githubUrl": "https://github.com/Nordstrom/serverless-attach-managed-policy",
     "status": "active"
-}, {
+  },
+  {
     "name": "serverless-plugin-reducer",
     "description": "Reduce Node.js lambda package so it contains only lambda dependencies",
     "githubUrl": "https://github.com/medikoo/serverless-plugin-reducer",
     "status": "active"
-}, {
+  },
+  {
     "name": "serverless-plugin-transpiler",
     "description": "Transpile lambda files during packaging step",
     "githubUrl": "https://github.com/medikoo/serverless-plugin-transpiler",
     "status": "active"
-}, {
+  },
+  {
     "name": "serverless-plugin-dynamodb-autoscaling",
     "description": "Auto generate auto scaling configuration for configured DynamoDB tables",
     "githubUrl": "https://github.com/medikoo/serverless-plugin-dynamodb-autoscaling",
     "status": "active"
-}, {
+  },
+  {
     "name": "serverless-plugin-vpc-eni-cleanup",
     "description": "Automatic cleanup of VPC network interfaces on stage removal",
     "githubUrl": "https://github.com/medikoo/serverless-plugin-vpc-eni-cleanup",
     "status": "active"
-}, {
+  },
+  {
     "name": "serverless-plugin-tracer",
     "description": "Trace serverless hooks as they execute",
     "githubUrl": "https://github.com/enykeev/serverless-plugin-tracer",
     "status": "active"
-}, {
+  },
+  {
     "name": "serverless-plugin-stackstorm",
     "description": "Reusable Functions from StackStorm Exchange",
     "githubUrl": "https://github.com/StackStorm/serverless-plugin-stackstorm",
     "status": "active"
-}, {
+  },
+  {
     "name": "serverless-iot-local",
     "description": "AWS Iot events with serverless-offline",
     "githubUrl": "https://github.com/tradle/serverless-iot-local",
     "status": "active"
-}, {
+  },
+  {
     "name": "serverless-sns-filter",
     "description": "Serverless plugin to add SNS Subscription Filters to events",
     "githubUrl": "https://github.com/MechanicalRock/serverless-sns-filter",
     "status": "active"
-}, {
+  },
+  {
     "name": "serverless-apigateway-route-settings",
     "description": "Configure Route Settings for HTTP API Gateway v2 (Throttling & Detailed Metrics)",
     "githubUrl": "https://github.com/talbotp/serverless-apigateway-route-settings",
     "status": "active"
-}, {
+  },
+  {
     "name": "serverless-plugin-tagsns",
     "description": "Serverless plugin to add Tags to SNS Topics",
     "githubUrl": "https://github.com/ManoManoTech/serverless-plugin-tagsns",
     "status": "active"
-}, {
+  },
+  {
     "name": "serverless-reqvalidator-plugin",
     "description": "Serverless plugin to add request validator to API Gateway methods",
     "githubUrl": "https://github.com/RafPe/serverless-reqvalidator-plugin",
     "status": "active"
-}, {
+  },
+  {
     "name": "serverless-plugin-conditional-functions",
     "description": "A plugin that allows adding simple feature flag per function via a boolean condition.",
     "githubUrl": "https://github.com/go-dima/serverless-plugin-conditional-functions",
     "status": "active"
-}, {
+  },
+  {
     "name": "serverless-ephemeral",
     "description": "Build and include custom stateless libraries for any language",
     "githubUrl": "https://github.com/Accenture/serverless-ephemeral",
     "status": "active"
-}, {
+  },
+  {
     "name": "serverless-content-encoding",
     "description": "Enable Content Encoding in AWS API Gateway during deployment",
     "githubUrl": "https://github.com/dong-dohai/serverless-content-encoding",
     "status": "active"
-}, {
+  },
+  {
     "name": "serverless-s3-encryption",
     "description": "Set or remove the encryption settings on your s3 buckets",
     "githubUrl": "https://github.com/tradle/serverless-s3-encryption",
     "status": "active"
-}, {
+  },
+  {
     "name": "serverless-plugin-inject-dependencies",
     "description": "Painlessly deploy serverless projects with only the required dependencies.",
     "githubUrl": "https://github.com/loanmarket/serverless-plugin-inject-dependencies",
     "status": "active"
-}, {
+  },
+  {
     "name": "serverless-plugin-provider-groups",
     "description": "A plugin to allow management of grouped settings within large serverless projects.",
     "githubUrl": "https://github.com/loanmarket/serverless-plugin-provider-groups",
     "status": "active"
-}, {
+  },
+  {
     "name": "serverless-cloudformation-resource-counter",
     "description": "A plugin to count the resources generated in the AWS CloudFormation stack after deployment.",
     "githubUrl": "https://github.com/drexler/serverless-cloudformation-resource-counter",
     "status": "active"
-}, {
+  },
+  {
     "name": "serverless-iam-roles-per-function",
     "description": "Serverless Plugin for easily defining IAM roles per function via the use of iamRoleStatements at the function level.",
     "githubUrl": "https://github.com/functionalone/serverless-iam-roles-per-function",
     "status": "active"
-}, {
+  },
+  {
     "name": "serverless-frontend-plugin",
     "description": "Deploy any type of frontend on AWS Cloudfront with Https/SSL termination with your serverless deployments. Integrates with serverless-offline for local development.",
     "githubUrl": "https://github.com/rogersgt/serverless-frontend-plugin",
     "status": "active"
-}, {
+  },
+  {
     "name": "@fernthedev/serverless-offline-step-functions",
     "description": "Serverless Offline Plugin to Support Step Functions for Local Development.",
     "githubUrl": "https://github.com/jefer590/serverless-offline-step-functions",
     "status": "active"
-},  {
+  },
+  {
     "name": "serverless-functions-base-path",
     "description": "Easily define a base path where your serverless functions are located.",
     "githubUrl": "https://github.com/kevinrambaud/serverless-functions-base-path",
     "status": "active"
-}, {
+  },
+  {
     "name": "serverless-static",
     "description": "Easily serve files from a folder while developing on localhost with the serverless-offline plugin",
     "githubUrl": "https://github.com/iliasbhal/serverless-static",
     "status": "active"
-}, {
+  },
+  {
     "name": "serverless-plugin-static",
     "description": "Serving static files locally with serverless-offline or a standalone command",
     "githubUrl": "https://github.com/a-pavlenko/serverless-plugin-static",
     "status": "active"
-}, {
+  },
+  {
     "name": "serverless-plugin-node-shim",
     "description": "Serverless plugin to run your functions in nodejs version (8 LTS, 9+) on aws lambda",
     "githubUrl": "https://github.com/jzimmek/serverless-plugin-node-shim",
     "status": "active"
-}, {
+  },
+  {
     "name": "serverless-sagemaker-groundtruth",
     "description": "Serverless Plugin with AWS Sagemaker Groundtruth utilities (local template testing, e2e tests ...)",
     "githubUrl": "https://github.com/piercus/serverless-sagemaker-groundtruth",
     "status": "active"
-}, {
+  },
+  {
     "name": "serverless-local-environment",
     "description": "Serverless plugin to set local environment variables and remote environment variable to different values",
     "githubUrl": "https://github.com/piercus/serverless-local-environment",
     "status": "active"
-}, {
+  },
+  {
     "name": "serverless-offline-schedule",
     "description": "Emulate schedule events locally when developing your Serverless project",
     "githubUrl": "https://github.com/Meemaw/serverless-offline-schedule",
     "status": "active"
-}, {
+  },
+  {
     "name": "serverless-cloudformation-sub-variables",
     "description": "Serverless framework plugin for easily supporting AWS CloudFormation Sub function variables",
     "githubUrl": "https://github.com/santiagocardenas/serverless-cloudformation-sub-variables",
     "status": "active"
-}, {
+  },
+  {
     "name": "serverless-sthree-env",
     "description": "Serverless plugin to get config from a json formatted file in S3 and copy them to environment variable",
     "githubUrl": "https://github.com/StyleTributeIT/serverless-sthree-env",
     "status": "active"
-}, {
+  },
+  {
     "name": "serverless-plugin-canary-deployments",
     "description": "A Serverless plugin to implement canary deployments of Lambda functions",
     "githubUrl": "https://github.com/davidgf/serverless-plugin-canary-deployments",
     "status": "active"
-}, {
+  },
+  {
     "name": "serverless-go-build",
     "description": "Build go source files (or public functions) using yml definition file",
     "githubUrl": "https://github.com/sean9keenan/serverless-go-build",
     "status": "active"
-}, {
+  },
+  {
     "name": "bref",
     "description": "Deploy serverless PHP applications to AWS Lambda",
     "githubUrl": "https://github.com/brefphp/bref",
     "status": "active"
-}, {
+  },
+  {
     "name": "serverless-local-schedule",
     "description": "Schedule AWS CloudWatch Event based invocations in local time(with DST support!)",
     "githubUrl": "https://github.com/UnitedIncome/serverless-local-schedule",
     "status": "active"
-}, {
+  },
+  {
     "name": "go-serverless",
     "description": "GoFormation for Serverless. Create serverless configs with Go Structs.",
     "githubUrl": "https://github.com/thepauleh/goserverless",
     "status": "active"
-}, {
+  },
+  {
     "name": "serverless-tag-sqs",
     "description": "Serverless plugin to tag SQS - Simple Queue Service",
     "githubUrl": "https://github.com/gfragoso/serverless-tag-sqs",
     "status": "active"
-}, {
+  },
+  {
     "name": "serverless-express",
     "description": "Making express app development compatible with serverless framework.",
     "githubUrl": "https://github.com/mikestaub/serverless-express",
     "status": "active"
-}, {
+  },
+  {
     "name": "serverless-aliyun-function-compute",
     "description": "Serverless Alibaba Cloud Function Compute Plugin",
     "githubUrl": "https://github.com/aliyun/serverless-aliyun-function-compute",
     "status": "active"
-}, {
+  },
+  {
     "name": "serverless-apib-validator",
     "description": "Validate that an API Blueprint has full coverage over a Serverless config",
     "githubUrl": "https://github.com/onlicar/serverless-apib-validator",
     "status": "active"
-}, {
+  },
+  {
     "name": "serverless-package-common",
     "description": "Deploy microservice Python Serverless services with common code",
     "githubUrl": "https://github.com/onlicar/serverless-package-common",
     "status": "active"
-}, {
+  },
+  {
     "name": "serverless-tag-api-gateway",
     "description": "Serverless plugin to tag API Gateway",
     "githubUrl": "https://github.com/gfragoso/serverless-tag-api-gateway",
     "status": "active"
-}, {
+  },
+  {
     "name": "serverless-tag-cloud-watch-logs",
     "description": "Serverless plugin to tag CloudWatchLogs",
     "githubUrl": "https://github.com/gfragoso/serverless-tag-cloud-watch-logs",
     "status": "active"
-}, {
+  },
+  {
     "name": "serverless-create-global-dynamodb-table",
     "description": "Serverless plugin to create dynamodb global tables",
     "githubUrl": "https://github.com/rrahul963/serverless-create-global-dynamodb-table",
     "status": "active"
-}, {
+  },
+  {
     "name": "serverless-ding",
     "description": "Serverless plugin to audibly alert user after deployment",
     "githubUrl": "https://github.com/sidgonuts/serverless-ding",
     "status": "active"
-}, {
+  },
+  {
     "name": "serverless-ignore",
     "description": "Serverless plugin to ignore files (.slsignore)",
     "githubUrl": "https://github.com/nya1/serverless-ignore",
     "status": "active"
-}, {
+  },
+  {
     "name": "serverless-add-api-key",
     "description": "Serverless plugin to add same api key for multiple serverless services i.e. to re-use apikey across multiple api gateway apis.",
     "githubUrl": "https://github.com/rrahul963/serverless-add-api-key",
     "status": "active"
-}, {
+  },
+  {
     "name": "serverless-puresec-cli",
     "description": "Serverless Plugin for magically creating IAM roles that are least privileged per function.",
     "githubUrl": "https://github.com/puresec/serverless-puresec-cli",
     "status": "active"
-}, {
+  },
+  {
     "name": "serverless-dependson-plugin",
     "description": "Serverless plugin that automatically generates DependsOn references for AWS Lambdas to prevent AWS RequestLimitExceeded errors.",
     "githubUrl": "https://github.com/bwinant/serverless-dependson-plugin",
     "status": "active"
-}, {
+  },
+  {
     "name": "serverless-plugin-colocate",
     "description": "Serverless Plugin to keep your configuration next to your code.",
     "githubUrl": "https://github.com/aronim/serverless-plugin-colocate",
     "status": "active"
-}, {
+  },
+  {
     "name": "serverless-plugin-fastdeploy",
     "description": "Serverless Plugin to perform fast deployments for large service packages.",
     "githubUrl": "https://github.com/aronim/serverless-plugin-fastdeploy",
     "status": "active"
-}, {
+  },
+  {
     "name": "serverless-plugin-parent",
     "description": "Serverless Plugin that allows you to keep common configuration in a parent serverless.yml",
     "githubUrl": "https://github.com/aronim/serverless-plugin-parent",
     "status": "active"
-}, {
+  },
+  {
     "name": "serverless-plugin-registry",
     "description": "Serverless plugin to register function names with AWS SSM Parameter Store.",
     "githubUrl": "https://github.com/aronim/serverless-plugin-registry",
     "status": "active"
-}, {
+  },
+  {
     "name": "serverless-plugin-offline-dynamodb-stream",
     "description": "Serverless Plugin for emulating dynamodb stream triggering lambda functions offline",
     "githubUrl": "https://github.com/orchestrated-io/serverless-plugin-offline-dynamodb-stream",
     "status": "active"
-}, {
+  },
+  {
     "name": "serverless-basic-authentication",
     "description": "Serverless Plugin for adding Basic Authentication to your api",
     "githubUrl": "https://github.com/svdgraaf/serverless-basic-authentication",
     "status": "active"
-}, {
+  },
+  {
     "name": "serverless-rust",
     "description": "Deploy Rustlang applications to AWS Lambda",
     "githubUrl": "https://github.com/softprops/serverless-rust",
     "status": "active"
-}, {
+  },
+  {
     "name": "sls-rust",
     "description": "A Serverless plugin to deploy Rust applications",
     "githubUrl": "https://github.com/fdaciuk/sls-rust",
     "status": "active"
-},{
+  },
+  {
     "name": "serverless-oncall",
     "description": "Easily manage oncall for your serverless services",
     "githubUrl": "https://github.com/softprops/serverless-oncall",
     "status": "active"
-}, {
+  },
+  {
     "name": "serverless-cognito-add-custom-attributes",
     "description": "Serverless Plugin for adding custom attributes to an existing CloudFormation-managed CognitoUserPool and CognitoUserPoolClient without losing all your users",
     "githubUrl": "https://github.com/GetWala/serverless-cognito-add-custom-attributes",
     "status": "active"
-}, {
+  },
+  {
     "name": "serverless-plugin-ifelse",
     "description": "A Serverless Plugin to write If Else conditions in serverless YAML file",
     "githubUrl": "https://github.com/anantab/serverless-plugin-ifelse",
     "status": "active"
-}, {
+  },
+  {
     "name": "serverless-print-dots",
     "description": "A Serverless plugin for printing dots in Serverless log during deployment to indicate progress and prevent timeouts in CI/CD platforms.",
     "githubUrl": "https://github.com/amirklick/serverless-print-dots",
     "status": "active"
-}, {
+  },
+  {
     "name": "serverless-es-logs",
     "description": "A Serverless plugin to transport logs to ElasticSearch",
     "githubUrl": "https://github.com/daniel-cottone/serverless-es-logs",
     "status": "active"
-}, {
+  },
+  {
     "name": "serverless-whitelisting",
     "description": "A Serverless plugin to create a whitelist for IP addresses, CIDR for a serverless application, using resource policies. Support privateStages, publicStages and publicPaths.",
     "githubUrl": "https://github.com/tho-asterist/serverless-whitelisting",
     "status": "active"
-}, {
+  },
+  {
     "name": "serverless-package-external",
     "description": "A Serverless plugin to add external folders to the deploy package",
     "githubUrl": "https://github.com/epsagon/serverless-package-external",
     "status": "active"
-}, {
+  },
+  {
     "name": "serverless-consul-variables",
     "description": "Retrieve serverless variables from Consul kv",
     "githubUrl": "https://github.com/zephrax/serverless-consul-variables",
     "status": "active"
-}, {
+  },
+  {
     "name": "serverless-iot-offline",
     "description": "Serverless plugin that emulates AWS IoT service",
     "githubUrl": "https://github.com/mitipi/serverless-iot-offline",
     "status": "active"
-}, {
+  },
+  {
     "name": "serverless-ngrok-tunnel",
     "description": "Serverless plugin that creates ngrok public tunnel on localhost",
     "githubUrl": "https://github.com/mitipi/serverless-ngrok-tunnel",
     "status": "active"
-}, {
+  },
+  {
     "name": "serverless-oauth-scopes",
     "description": "A serverless plugin to set OAuth Scopes on APIGateway methods",
     "githubUrl": "https://github.com/birdcatcher/serverless-oauth-scopes",
     "status": "active"
-}, {
+  },
+  {
     "name": "@haftahave/serverless-ses-template",
     "description": "A serveless plugin that allows automatically creating, updating and removing AWS SES Templates using a configuration file and keeps your AWS SES Templates synced with your configuration file.",
     "githubUrl": "https://github.com/haftahave/serverless-ses-template",
     "status": "active"
-}, {
+  },
+  {
     "name": "serverless-api-gateway-caching",
     "description": "Serverless plugin which configures API Gateway caching",
     "githubUrl": "https://github.com/DianaIonita/serverless-api-gateway-caching",
     "status": "active"
-}, {
+  },
+  {
     "name": "serverless-api-gateway-throttling",
     "description": "Serverless plugin which configures throttling for API Gateway endpoints",
     "githubUrl": "https://github.com/DianaIonita/serverless-api-gateway-throttling",
     "status": "active"
-}, {
+  },
+  {
     "name": "serverless-vpc-plugin",
     "description": "Serverless plugin to create a VPC",
     "githubUrl": "https://github.com/smoketurner/serverless-vpc-plugin",
     "status": "active"
-}, {
+  },
+  {
     "name": "serverless-plugin-monorepo",
     "description": "A serverless plugin that allows use of serverless in a mono repo. Avoids needing to use nohoist by automatic symlinking of all dependencies.",
     "githubUrl": "https://github.com/Butterwire/serverless-plugin-monorepo",
     "status": "active"
-}, {
+  },
+  {
     "name": "serverless-version-tracker",
     "description": "A serverless plugin for tracking deployed versions of your code.",
     "githubUrl": "https://github.com/danepowell/serverless-version-tracker",
     "status": "active"
-}, {
+  },
+  {
     "name": "serverless-confirm-command",
     "description": "Make commands (and provider-specific options) requiring confirmation before execution.",
     "githubUrl": "https://github.com/teddy-gustiaux/serverless-confirm-command",
     "status": "active"
-}, {
+  },
+  {
     "name": "serverless-workspaces-plugin",
     "description": "Resolve and Symlink hoisted dependencies when individually packaging each function",
     "githubUrl": "https://github.com/sergioramos/serverless-workspaces-plugin",
     "status": "inactive"
-}, {
+  },
+  {
     "name": "serverless-cloudflare-workers",
     "description": "A serverless plugin allowing you to integrate with [Cloudflare Workers](https://cloudflareworkers.com/#12a9195720fe4ed660949efdbd9c0219:https://tutorial.cloudflareworkers.com)",
     "githubUrl": "https://github.com/cloudflare/serverless-cloudflare-workers",
     "status": "active"
-}, {
+  },
+  {
     "name": "@endemolshinegroup/serverless-dynamodb-autoscaler",
     "description": "Autoscale DynamoDB resources with a single AWS AutoScalingPlan",
     "githubUrl": "https://github.com/EndemolShineGroup/serverless-dynamodb-autoscaler",
     "status": "active"
-}, {
-  "name": "serverless-plugin-decouple",
-  "description": "Remove ImportValue dependencies by replacing them with the actual values in order to update base exports",
-  "githubUrl": "https://github.com/mutual-of-enumclaw/serverless-plugin-decouple",
-  "status": "active"
-}, {
+  },
+  {
+    "name": "serverless-plugin-decouple",
+    "description": "Remove ImportValue dependencies by replacing them with the actual values in order to update base exports",
+    "githubUrl": "https://github.com/mutual-of-enumclaw/serverless-plugin-decouple",
+    "status": "active"
+  },
+  {
     "name": "serverless-docker-artifacts",
     "description": "Build your artifacts within docker container.",
     "githubUrl": "https://github.com/Suor/serverless-docker-artifacts",
     "status": "active"
-}, {
+  },
+  {
     "name": "serverless-tesseract",
     "description": "Add Tesseract OCR Engine to your build.",
     "githubUrl": "https://github.com/Suor/serverless-tesseract",
     "status": "active"
-}, {
+  },
+  {
     "name": "aws-cognito-idp-userpool-domain",
     "description": "Manage (add and remove) aws hosted domain on Cognito Userpools",
     "githubUrl": "https://github.com/rubentrancoso/aws-cognito-idp-userpool-domain",
     "status": "active"
-}, {
+  },
+  {
     "name": "serverless-parcel",
     "description": "A Serverless plugin to bundle your functions and assets with Parcel Bundler",
     "githubUrl": "https://github.com/johnagan/serverless-parcel",
     "status": "active"
-}, {
+  },
+  {
     "name": "serverless-vault-plugin",
     "description": "A Serverless plugin to retrieve passwords from vault and encrypt to kms",
     "githubUrl": "https://github.com/Rondineli/serverless-vault-plugin",
     "status": "active"
-}, {
+  },
+  {
     "name": "serverless-function-outputs",
     "description": "Adds function Name and ARN outputs without version suffix",
     "githubUrl": "https://github.com/RogerBarreto/serverless-function-outputs",
     "status": "active"
-}, {
-  "name": "serverless-website-domain",
-  "description": "A plugin that creates Route 53 records that point to your Cloudfront hosted static website, including www/non-www redirects.",
-  "githubUrl": "https://github.com/williamsandonz/serverless-website-domain",
-  "status": "active"
-},
-{
-  "name": "serverless-output-to-env",
-  "description": "A Serverless plugin that writes stack outputs to an .env file during the after:deploy hook.",
-  "githubUrl": "https://github.com/williamsandonz/serverless-output-to-env",
-  "status": "active"
-},
-{
+  },
+  {
+    "name": "serverless-website-domain",
+    "description": "A plugin that creates Route 53 records that point to your Cloudfront hosted static website, including www/non-www redirects.",
+    "githubUrl": "https://github.com/williamsandonz/serverless-website-domain",
+    "status": "active"
+  },
+  {
+    "name": "serverless-output-to-env",
+    "description": "A Serverless plugin that writes stack outputs to an .env file during the after:deploy hook.",
+    "githubUrl": "https://github.com/williamsandonz/serverless-output-to-env",
+    "status": "active"
+  },
+  {
     "name": "serverless-kms-grants",
     "description": "Create and revoke grants for AWS Lambda functions to use KMS keys.",
     "githubUrl": "https://github.com/deep-security/serverless-kms-grants",
     "status": "active"
-}, {
+  },
+  {
     "name": "serverless-rack",
     "description": "Serverless plugin to deploy Ruby Rack applications (Sinatra/Padrino/Cuba etc.)",
     "githubUrl": "https://github.com/logandk/serverless-rack",
     "status": "active"
-}, {
+  },
+  {
     "name": "serverless-ruby-package",
     "description": "Improves packaging and deploying gems for Ruby services",
     "githubUrl": "https://github.com/joshuaflanagan/serverless-ruby-package",
     "status": "active"
-}, {
+  },
+  {
     "name": "serverless-plugin-parcel",
     "description": "Serverless Parcel plugin with watch mode and serverless-offline support",
     "githubUrl": "https://github.com/threadheap/serverless-plugin-parcel",
     "status": "active"
-}, {
+  },
+  {
     "name": "serverless-plugin-tree-shake",
     "description": "Shake the dependency tree and only package files needed",
     "githubUrl": "https://github.com/sergioramos/serverless-plugin-tree-shake",
     "status": "active"
-}, {
+  },
+  {
     "name": "serverless-plugin-typescript-express",
     "description": "Serverless plugin Typescript support with express integration",
     "githubUrl": "https://github.com/eliasjcjunior/serverless-plugin-typescript-express",
     "status": "active"
-}, {
+  },
+  {
     "name": "serverless-aws-static-file-handler",
     "description": "An easy way to host the front-end of your web applications on Serverless framework on AWS Lambda along with their APIs written in Serverless.",
     "githubUrl": "https://github.com/activescott/serverless-aws-static-file-handler",
     "status": "active"
-}, {
+  },
+  {
     "name": "serverless-http-invoker",
     "description": "Locally invoke Serverless functions via their HTTP event as specified in Serverless.yml. It makes it easy to test not only your handler logic, but also ensures that you have your http events setup properly in serverless.yml without deploying.",
     "githubUrl": "https://github.com/activescott/serverless-http-invoker",
     "status": "active"
-}, {
+  },
+  {
     "name": "serverless-plugin-cloudwatch-dashboard",
     "description": "Serverless plugin to generate AWS CloudWatch dashboard for AWS Lambda functions",
     "githubUrl": "https://github.com/codecentric/serverless-plugin-cloudwatch-dashboard",
     "status": "active"
-}, {
+  },
+  {
     "name": "serverless-create-dynamodb-global-tables-for-cf-stack",
     "description": "Create and replicate global dynamodb tables",
     "githubUrl": "https://github.com/Imran99/serverless-create-dynamodb-global-tables-for-cf-stack",
     "status": "active"
-}, {
+  },
+  {
     "name": "serverless-tencent-scf",
     "description": "Serverless framework provider plugin for Tencent SCF(Serverless Cloud Function)",
     "githubUrl": "https://github.com/tencentyun/serverless-tencent-cloud-function",
     "status": "active"
-}, {
+  },
+  {
     "name": "serverless-plugin-staging",
     "description": "A plugin to restrict the deployment of resources or functions on a per stage basis",
     "githubUrl": "https://github.com/icarus-sullivan/serverless-plugin-staging",
     "status": "active"
-}, {
+  },
+  {
     "name": "serverless-fargate-tasks",
     "description": "A plugin to run fargate tasks as part of your Serverless project",
     "githubUrl": "https://github.com/svdgraaf/serverless-fargate-tasks",
     "status": "active"
-}, {
+  },
+  {
     "name": "serverless-plugin-composed-vars",
     "description": "A plugin that composes custom and environment variables based on the deployment stage",
     "githubUrl": "https://github.com/chris-feist/serverless-plugin-composed-vars",
     "status": "active"
-}, {
+  },
+  {
     "name": "serverless-multi-region-plugin",
     "description": "A plugin for setting up a serverless API in AWS with turnkey multi-region failover",
     "githubUrl": "https://github.com/unbill/serverless-multi-region-plugin",
     "status": "active"
-}, {
+  },
+  {
     "name": "serverless-plugin-pubsub",
     "description": "Simple pub/sub configuration with queueing for the Serverless Framework",
     "githubUrl": "https://github.com/fivepapertigers/serverless-plugin-pubsub",
     "status": "active"
-}, {
+  },
+  {
     "name": "serverless-import-apigateway",
     "description": "Dynamically import an existing AWS API Gateway into your Serverless stack",
     "githubUrl": "https://github.com/mikesouza/serverless-import-apigateway",
     "status": "active"
-}, {
+  },
+  {
     "name": "serverless-associate-waf",
     "description": "Associate a regional WAF with the AWS API Gateway used by your Serverless stack",
     "githubUrl": "https://github.com/mikesouza/serverless-associate-waf",
     "status": "active"
-}, {
+  },
+  {
     "name": "serverless-deployment-bucket",
     "description": "Create and configure the custom Serverless deployment bucket",
     "githubUrl": "https://github.com/mikesouza/serverless-deployment-bucket",
     "status": "active"
-}, {
+  },
+  {
     "name": "serverless-manifest-plugin",
     "description": "Generate manifest of api endpoints & stack outputs for consumption in other applications + service discovery",
     "githubUrl": "https://github.com/DavidWells/serverless-manifest-plugin",
     "status": "active"
-}, {
+  },
+  {
     "name": "serverless-local-kinesis",
     "description": "Run a local kinesis and automatically fire events",
     "githubUrl": "https://github.com/pidz-development/serverless-local-kinesis",
     "status": "active"
-}, {
+  },
+  {
     "name": "serverless-nextjs-plugin",
     "description": "Deploy serverless next apps with ease",
     "githubUrl": "https://github.com/danielcondemarin/serverless-nextjs-plugin",
     "status": "active"
-}, {
+  },
+  {
     "name": "serverless-plugin-tables",
     "description": "Easily configure table resources, such as DynamoDB",
     "githubUrl": "https://github.com/chris-feist/serverless-plugin-tables",
     "status": "active"
-}, {
+  },
+  {
     "name": "serverless-iopipe-layers",
     "description": "Monitor, observe and profile your AWS Lambda functions without a code change",
     "githubUrl": "https://github.com/iopipe/serverless-iopipe-layers",
     "status": "active"
-}, {
+  },
+  {
     "name": "serverless-cloudside-plugin",
     "description": "Easily reference and use cloudside resources during local development and testing",
     "githubUrl": "https://github.com/jeremydaly/serverless-cloudside-plugin",
     "status": "active"
-}, {
+  },
+  {
     "name": "serverless-jetpack",
     "description": "A faster JavaScript packager for Serverless applications",
     "githubUrl": "https://github.com/FormidableLabs/serverless-jetpack",
     "status": "active"
-}, {
+  },
+  {
     "name": "serverless-offline-http-mock",
     "description": "Create mock responses to HTTP(S) requests for local development",
     "githubUrl": "https://github.com/pianomansam/serverless-offline-http-mock",
     "status": "active"
-}, {
+  },
+  {
     "name": "serverless-externals-plugin",
     "description": "Only include listed node modules and their dependencies in Serverless, with support for Rollup and Webpack",
     "githubUrl": "https://github.com/hansottowirtz/serverless-externals-plugin",
     "status": "active"
-}, {
+  },
+  {
     "name": "api-gateway-stage-tag-plugin",
     "description": "A shim to tag API Gateway stages until CloudFormation/Serverless support arrives.",
     "githubUrl": "https://github.com/mikepatrick/api-gateway-stage-tag-plugin",
     "status": "active"
-}, {
+  },
+  {
     "name": "serverless-api-compression",
     "description": "Serverless plugin that enables/disables content compression setting in API Gateway",
     "githubUrl": "https://github.com/evgenykireev/serverless-api-compression",
     "status": "active"
-}, {
+  },
+  {
     "name": "serverless-aws-documentation",
     "description": "Serverless 1.0 plugin to add documentation and models to the serverless generated API Gateway",
     "githubUrl": "https://github.com/deliveryhero/serverless-aws-documentation",
     "status": "active"
-}, {
+  },
+  {
     "name": "serverless-http",
     "description": "Use your existing middleware framework (e.g. Express, Koa) in AWS Lambda",
     "githubUrl": "https://github.com/dougmoscrop/serverless-http",
     "status": "active"
-}, {
+  },
+  {
     "name": "serverless-snowflake-external-function-plugin",
     "description": "Serverless Plugin for deploying Snowflake External Functions",
     "githubUrl": "https://github.com/starschema/serverless-snowflake-external-function-plugin",
     "status": "active"
-}, {
+  },
+  {
     "name": "serverless-mysql",
     "description": "A module for managing MySQL connections at SERVERLESS scale",
     "githubUrl": "https://github.com/jeremydaly/serverless-mysql",
     "status": "active"
-}, {
+  },
+  {
     "name": "serverless-offline-kinesis",
     "description": "This Serverless-offline-kinesis plugin emulates AWS λ and Kinesis streams on your local machine.",
     "githubUrl": "https://github.com/CoorpAcademy/serverless-plugins/tree/master/packages/serverless-offline-kinesis",
     "status": "active"
-}, {
+  },
+  {
     "name": "serverless-offline-python",
     "description": "Emulate AWS λ and API Gateway locally when developing your Serverless project",
     "githubUrl": "https://github.com/alhazmy13/serverless-offline-python",
     "status": "active"
-}, {
+  },
+  {
     "name": "serverless-openapi-documentation",
     "description": "Serverless 1.0 plugin to generate OpenAPI V3 documentation from serverless configuration",
     "githubUrl": "https://github.com/temando/serverless-openapi-documentation",
     "status": "active"
-}, {
+  },
+  {
     "name": "serverless-openwhisk",
     "description": "Adds Apache OpenWhisk support to the Serverless Framework!",
     "githubUrl": "https://github.com/serverless/serverless-openwhisk",
     "status": "active"
-}, {
+  },
+  {
     "name": "serverless-plugin-cloudfront-lambda-edge",
     "description": "Adds Lambda@Edge support to Serverless",
     "githubUrl": "https://github.com/silvermine/serverless-plugin-cloudfront-lambda-edge",
     "status": "active"
-}, {
+  },
+  {
     "name": "serverless-plugin-cronjob",
     "description": "This plugin creates cronjobs out of your lambda functions.",
     "githubUrl": "https://github.com/martinlindenberg/serverless-plugin-cronjob",
     "status": "active"
-}, {
+  },
+  {
     "name": "serverless-plugin-custom-roles",
     "description": "A Serverless plugin that makes creation of per function IAM roles easier.",
     "githubUrl": "https://github.com/AntonBazhal/serverless-plugin-custom-roles",
     "status": "active"
-}, {
+  },
+  {
     "name": "serverless-plugin-existing-s3",
     "description": "Overcomes the CloudFormation limitation on attaching an event to an uncontrolled bucket, for Serverless.com 1.11.0+.",
     "githubUrl": "https://github.com/matt-filion/serverless-external-s3-event",
     "status": "active"
-}, {
+  },
+  {
     "name": "serverless-plugin-log-retention",
     "description": "Control the retention of your serverless function's cloudwatch logs.",
     "githubUrl": "https://github.com/ArtificerEntertainment/serverless-plugin-log-retention",
     "status": "active"
-}, {
+  },
+  {
     "name": "serverless-plugin-newman",
     "description": "A serverless plugin for newman.",
     "githubUrl": "https://github.com/rawphp/serverless-plugin-newman",
     "status": "active"
-}, {
+  },
+  {
     "name": "serverless-plugin-tracing",
     "description": "Enables AWS X-Ray (https://aws.amazon.com/xray/) for the entire Serverless stack or individual functions.",
     "githubUrl": "https://github.com/alex-murashkin/serverless-plugin-tracing",
     "status": "active"
-}, {
+  },
+  {
     "name": "serverless-s3-deploy",
     "description": "Plugin for serverless to deploy files to a variety of S3 Buckets",
     "githubUrl": "https://github.com/funkybob/serverless-s3-deploy",
     "status": "active"
-}, {
+  },
+  {
     "name": "serverless-scheduled-functions",
     "description": "Schedule your serverless functions",
     "githubUrl": "https://github.com/reactor-studio/serverless-scheduled-functions",
     "status": "active"
-}, {
+  },
+  {
     "name": "serverless-step-functions-offline",
     "description": "Emulate step functions locally when developing your Serverless project ",
     "githubUrl": "https://github.com/vkkis93/serverless-step-functions-offline",
@@ -1841,5 +2185,10 @@
     "description": "Automatically create CloudWatch alarms and dashboards for Lambda, SQS, Kinesis, DynamoDB, API Gateway and Step Functions",
     "githubUrl": "https://github.com/fourTheorem/slic-watch",
     "status": "active"
+  },
+  {
+    "name": "serverless-configure-lambda-logs",
+    "description": "Plugin that configures Lambda logs with CloudWatch log groups and subscriptions",
+    "githubUrl": "https://github.com/vavasilva/serverless-configure-lamba-logs"
   }
 ]

--- a/plugins.json
+++ b/plugins.json
@@ -1,1797 +1,1500 @@
-[
-  {
-    "name": "@kakkuk/serverless-aws-lambda-dynamic-trigger",
-    "description": "Allows to register sns, sqs and kinesis triggers (events) dynamically.",
-    "githubUrl": "https://github.com/failsafe-engineering/serverless-aws-lambda-dynamic-trigger",
-    "status": "active"
-  },
-  {
-    "name": "@kakkuk/serverless-aws-apigateway-documentation",
-    "description": "Adds support for AWS API Gateway documentation and model",
-    "githubUrl": "https://github.com/failsafe-engineering/serverless-aws-apigateway-documentation",
-    "status": "active"
-  },
-  {
-    "name": "@vulcancreative/serverless-storage",
-    "description": "Serverless plugin defining DynamoDB storage primitives; like localStorage but better",
-    "githubUrl": "https://github.com/vulcancreative/serverless-storage",
-    "status": "active"
-  },
-  {
-    "name": "serverless-aws-function-url-custom-domain",
-    "description": "Setup cloudfront distrubution and route53 record for AWS Lambda with Function URL",
-    "githubUrl": "https://github.com/wangsha/serverless-aws-function-url-custom-domain",
-    "status": "active"
-  },
-  {
-    "name": "serverless-plugin-typetalk",
-    "description": "Sends notification to Typetalk",
-    "githubUrl": "https://github.com/is2ei/serverless-plugin-typetalk",
-    "status": "active"
-  },
-  {
-    "name": "serverless-aws-lambda",
-    "description": "Plug & Play AWS Lambda NodeJS development tool with local API Gateway and Application Load Balancer support.",
-    "githubUrl": "https://github.com/Inqnuam/serverless-aws-lambda",
-    "status": "active"
-  },
-  {
-    "name": "serverless-app-client-credentials-to-ssm",
-    "description": "Export Cognito app client credentials to SSM Parameter store",
-    "githubUrl": "https://github.com/GaaraZhu/serverless-app-client-credentials-to-ssm",
-    "status": "active"
-  },
-  {
-    "name": "serverless-prune-versions",
-    "description": "Automatic deletion of old Lambda and Lambda Layer versions",
-    "githubUrl": "https://github.com/manwaring/serverless-prune-versions",
-    "status": "active"
-  },
-  {
-    "name": "serverless-log-metric-filter",
-    "description": "Add Cloudwatch Log Metric Filter to Cloudwatch Logs",
-    "githubUrl": "https://github.com/saqemlas/serverless-log-metric-filter",
-    "status": "active"
-  },
+[{
+  "name": "@kakkuk/serverless-aws-lambda-dynamic-trigger",
+  "description": "Allows to register sns, sqs and kinesis triggers (events) dynamically.",
+  "githubUrl": "https://github.com/failsafe-engineering/serverless-aws-lambda-dynamic-trigger",
+  "status": "active"
+},{
+  "name": "@kakkuk/serverless-aws-apigateway-documentation",
+  "description": "Adds support for AWS API Gateway documentation and model",
+  "githubUrl": "https://github.com/failsafe-engineering/serverless-aws-apigateway-documentation",
+  "status": "active"
+},{
+  "name": "@vulcancreative/serverless-storage",
+  "description": "Serverless plugin defining DynamoDB storage primitives; like localStorage but better",
+  "githubUrl": "https://github.com/vulcancreative/serverless-storage",
+  "status": "active"
+},{
+  "name": "serverless-aws-function-url-custom-domain",
+  "description": "Setup cloudfront distrubution and route53 record for AWS Lambda with Function URL",
+  "githubUrl": "https://github.com/wangsha/serverless-aws-function-url-custom-domain",
+  "status": "active"
+},{
+  "name": "serverless-plugin-typetalk",
+  "description": "Sends notification to Typetalk",
+  "githubUrl": "https://github.com/is2ei/serverless-plugin-typetalk",
+  "status": "active"
+}, {
+  "name": "serverless-aws-lambda",
+  "description": "Plug & Play AWS Lambda NodeJS development tool with local API Gateway and Application Load Balancer support.",
+  "githubUrl": "https://github.com/Inqnuam/serverless-aws-lambda",
+  "status": "active"
+},{
+  "name": "serverless-app-client-credentials-to-ssm",
+  "description": "Export Cognito app client credentials to SSM Parameter store",
+  "githubUrl": "https://github.com/GaaraZhu/serverless-app-client-credentials-to-ssm",
+  "status": "active"
+}, {
+  "name": "serverless-prune-versions",
+  "description": "Automatic deletion of old Lambda and Lambda Layer versions",
+  "githubUrl": "https://github.com/manwaring/serverless-prune-versions",
+  "status": "active"
+}, {
+  "name": "serverless-log-metric-filter",
+  "description": "Add Cloudwatch Log Metric Filter to Cloudwatch Logs",
+  "githubUrl": "https://github.com/saqemlas/serverless-log-metric-filter",
+  "status": "active"
+},
   {
     "name": "serverless-plugin-sumologic",
     "description": "This Serverless plugin deploys Cloudformation Stack with resources required to send Cloudformation Logs to Sumologic. This stack uses AWS Lambda to subscribe to your CloudWatch Log Group and POSTs the log data directly to Sumo HTTP Source.",
     "githubUrl": "https://github.com/ACloudGuru/serverless-plugin-sumologic",
     "status": "active"
-  },
-  {
-    "name": "serverless-plugin-apollo-graphql-federation",
-    "description": "A Serverless Framework that uploads a graphql schema to the Apollo Platform managed federation service",
-    "githubUrl": "https://github.com/Imran99/serverless-plugin-apollo-graphql-federation",
-    "status": "active"
-  },
-  {
-    "name": "serverless-plugin-modularize",
-    "description": "Modularize your serverless definitions",
-    "githubUrl": "https://github.com/icarus-sullivan/serverless-plugin-modularize",
-    "status": "active"
-  },
-  {
-    "name": "@stratiformdigital/serverless-online",
-    "description": "Faster lambda development in AWS through hot deploys and streaming logs.",
-    "githubUrl": "https://github.com/stratiformdigital/serverless-online",
-    "status": "active"
-  },
-  {
-    "name": "@stratiformdigital/serverless-iam-helper",
-    "description": "Applies IAM Path and PermissionsBoundary settings in hard to reach places.",
-    "githubUrl": "https://github.com/stratiformdigital/serverless-iam-helper",
-    "status": "active"
-  },
-  {
-    "name": "@stratiformdigital/serverless-idempotency-helper",
-    "description": "Helps make lambda deployments idempotent",
-    "githubUrl": "https://github.com/stratiformdigital/serverless-idempotency-helper",
-    "status": "active"
-  },
-  {
-    "name": "@stratiformdigital/serverless-s3-security-helper",
-    "description": "Sets security minded settings on s3 buckets, including sls deployment buckets",
-    "githubUrl": "https://github.com/stratiformdigital/serverless-s3-security-helper",
-    "status": "active"
-  },
-  {
-    "name": "serverless-provisioned-concurrency-autoscaling",
-    "description": "Serverless Plugin for AWS Lambda Provisioned Concurrency Auto Scaling configuration",
-    "githubUrl": "https://github.com/neiman-marcus/serverless-provisioned-concurrency-autoscaling",
-    "status": "active"
-  },
-  {
-    "name": "serverless-localstack",
-    "description": "Serverless plugin for LocalStack - a fully functional local AWS cloud stack. Develop and test your cloud & Serverless apps offline!",
-    "githubUrl": "https://github.com/LocalStack/serverless-localstack",
-    "status": "active"
-  },
-  {
-    "name": "serverless-commercetools-plugin",
-    "description": "Serverless framework plugin that registers the deployed function as a commercetools API Extension or attaches it to a Subscription.",
-    "githubUrl": "https://github.com/commercetools/serverless-commercetools-plugin",
-    "status": "active"
-  },
-  {
-    "name": "serverless-plugin-test-helper",
-    "description": "Makes it easier to end-to-end test deployed deployed services by saving CloudFormation Stack Outputs locally and exposing values via a simple Node.js library",
-    "githubUrl": "https://github.com/manwaring/serverless-plugin-test-helper",
-    "status": "active"
-  },
-  {
-    "name": "serverless-plugin-dart",
-    "description": "Deploy Dart applications to AWS Lambda",
-    "githubUrl": "https://github.com/katallaxie/serverless-dart",
-    "status": "active"
-  },
-  {
-    "name": "serverless-scaleway-serverless",
-    "description": "This plugin enables support for Scaleway Serverless Functions and Serverless Containers betas within the Serverless Framework",
-    "githubUrl": "https://github.com/scaleway/serverless-scaleway-functions",
-    "status": "active"
-  },
-  {
-    "name": "serverless-plugin-iam-checker",
-    "description": "Helps automate security controls by preventing overly broad IAM permissions via customizable rules for both actions and resource references. Ships with restrictive defaults and supports custom rule configurations via serverless.yml and environment variables",
-    "githubUrl": "https://github.com/manwaring/serverless-plugin-iam-checker",
-    "status": "active"
-  },
-  {
-    "name": "serverless-plugin-layer-manager",
-    "description": "Plugin for improved AWS Lambda layer management, including install hooks, export options and improved retain support",
-    "githubUrl": "https://github.com/henhal/serverless-plugin-layer-manager",
-    "status": "active"
-  },
-  {
-    "name": "serverless-plugin-lambda-edge",
-    "description": "Plugin for Lambda@Edge, just associating your Lambda function with existing CloudFront distribution via AWS SDK",
-    "githubUrl": "https://github.com/isudzumi/serverless-plugin-lambda-edge",
-    "status": "active"
-  },
-  {
-    "name": "serverless-export-outputs",
-    "description": "A Serverless plugin for exporting AWS stack outputs to a file",
-    "githubUrl": "https://github.com/honarpour/serverless-export-outputs",
-    "status": "active"
-  },
-  {
-    "name": "serverless-plugin-apigateway-sqs",
-    "description": "Plugin that creates an AWS APIGateway resource to connect to an AWS Simple Queue Service (SQS) without the use of a lambda.",
-    "githubUrl": "https://github.com/CodeRecipe-dev/serverless-apigw-sqs-plugin",
-    "status": "active"
-  },
-  {
-    "name": "serverless-mongodb-local",
-    "description": "Serverless MongoDB local plugin",
-    "githubUrl": "https://github.com/bealearts/serverless-mongodb-local",
-    "status": "active"
-  },
-  {
-    "name": "serverless-plugin-utils",
-    "description": "A collection of serverless framework utilities",
-    "githubUrl": "https://github.com/icarus-sullivan/serverless-plugin-utils",
-    "status": "active"
-  },
-  {
-    "name": "serverless-layers",
-    "description": "How to reduce drastically lambda size",
-    "githubUrl": "https://github.com/agutoli/serverless-layers",
-    "status": "active"
-  },
-  {
-    "name": "mfa-serverless-plugin",
-    "description": "A simple plugin for deployment accounts with MFA",
-    "githubUrl": "https://github.com/alikian/mfa-serverless-plugin",
-    "status": "active"
-  },
-  {
-    "name": "serverless-ini-env",
-    "description": "Nice Serverless plugin to setup environment variables with ini file",
-    "githubUrl": "https://github.com/agutoli/serverless-ini-env",
-    "status": "active"
-  },
-  {
-    "name": "serverless-websockets-plugin",
-    "description": "Websocket support for Serverless Framework on AWS",
-    "githubUrl": "https://github.com/serverless/serverless-websockets-plugin",
-    "status": "active"
-  },
-  {
-    "name": "serverless-resource-policy",
-    "description": "Creates a whitelist of IP or CIDR addresses using serverless resource policies",
-    "githubUrl": "https://github.com/HubSpotWebTeam/serverless-resource-policy",
-    "status": "active"
-  },
-  {
-    "name": "serverless-plugin-vault-v2",
-    "description": "Simplify integration between serverless and vault to storage environments variables",
-    "githubUrl": "https://github.com/eliasjcjunior/serverless-plugin-vault-v2",
-    "status": "active"
-  },
-  {
-    "name": "serverless-plugin-powertools",
-    "description": "Serverless plugin adding several variable tools, resolvers, and commands",
-    "githubUrl": "https://github.com/whardier/serverless-plugin-powertools",
-    "status": "active"
-  },
-  {
-    "name": "serverless-justauthenticateme-plugin",
-    "description": "Use JustAuthenticateMe to easily authenticate users before hitting your lambdas",
-    "githubUrl": "https://github.com/CoalesceSoftware/serverless-justauthenticateme-plugin",
-    "status": "active"
-  },
-  {
-    "name": "serverless-openapi-plugin",
-    "description": "Serverless plugin to generate serverless API architecture from OpenAPI definition.",
-    "githubUrl": "https://github.com/jaumard/serverless-openapi-plugin",
-    "status": "active"
-  },
-  {
-    "name": "serverless-dotenv-plugin",
-    "description": "Preload environment variables from `.env` into serverless.",
-    "githubUrl": "https://github.com/infrontlabs/serverless-dotenv-plugin",
-    "status": "active"
-  },
-  {
-    "name": "serverless-disable-request-validators",
-    "description": "Serverless v2/v3 plugin to disable API Gateway request validators.",
-    "githubUrl": "https://github.com/jweyrich/serverless-disable-request-validators",
-    "status": "active"
-  },
-  {
-    "name": "serverless-default-aws-resource-attributes",
-    "description": "Set default attributes a given CloudFormation resource should have based on type.",
-    "githubUrl": "https://github.com/neverendingqs/serverless-default-aws-resource-attributes",
-    "status": "active"
-  },
-  {
-    "name": "serverless-stack-policy-by-resource-type",
-    "description": "Serverless Framework plugin for automatically populating CloudFormation stack policy statements by resource type.",
-    "githubUrl": "https://github.com/neverendingqs/serverless-stack-policy-by-resource-type",
-    "status": "active"
-  },
-  {
-    "name": "serverless-print-resolved-plugin",
-    "description": "Generate a copy of serverless.yml with all variables resolved.",
-    "githubUrl": "https://github.com/neverendingqs/serverless-print-resolved-plugin",
-    "status": "active"
-  },
-  {
-    "name": "serverless-discovery-plugin",
-    "description": "A serverless plugin to register AWS micro-service endpoints with a discovery service at serverless deploy or serverless remove time.",
-    "githubUrl": "https://github.com/aregier/serverless-discovery-plugin",
-    "status": "active"
-  },
-  {
-    "name": "fullstack-serverless",
-    "description": "A Serverless plugin to create an AWS CloudFront distribution that serves static web content from S3 and routes API traffic to API Gateway.",
-    "githubUrl": "https://github.com/MadSkills-io/fullstack-serverless",
-    "status": "active"
-  },
-  {
-    "name": "serverless-finch",
-    "description": "A Serverless plugin to deploy static website assets to AWS S3.",
-    "githubUrl": "https://github.com/fernando-mc/serverless-finch",
-    "status": "active"
-  },
-  {
-    "name": "serverless-appsync-plugin",
-    "description": "Serverless Plugin to deploy AppSync GraphQL API",
-    "githubUrl": "https://github.com/sid88in/serverless-appsync-plugin",
-    "status": "active"
-  },
-  {
-    "name": "serverless-appsync-simulator",
-    "description": "Offline support for serverless-appsync-plugin",
-    "githubUrl": "https://github.com/bboure/serverless-appsync-simulator",
-    "status": "active"
-  },
-  {
-    "name": "serverless-remote-json-envs",
-    "description": "Allows to use plain JSON files in remote locations being parsed as environment variables in lambda",
-    "githubUrl": "https://github.com/juancarestre/serverless-remote-json-envs",
-    "status": "active"
-  },
-  {
-    "name": "serverless-plugin-tag-cloud-watch-logs",
-    "description": "Small serverless plugin providing a way to add tags to CloudWatch resources",
-    "githubUrl": "https://github.com/pretty-fun-therapy/serverless-plugin-tag-cloud-watch-logs",
-    "status": "active"
-  },
-  {
-    "name": "serverless-appsync-offline",
-    "description": "Serverless Plugin to run AWS AppSync GraphQL API localy with dynamoDB and lambda resolvers",
-    "githubUrl": "https://github.com/aheissenberger/serverless-appsync-offline",
-    "status": "active"
-  },
-  {
-    "name": "aws-amplify-serverless-plugin",
-    "description": "Generate client-side configuration files for the AWS Amplify library based on your deployed Serverless backend",
-    "githubUrl": "https://github.com/awslabs/aws-amplify-serverless-plugin",
-    "status": "active"
-  },
-  {
-    "name": "serverless-amplify-auth",
-    "description": "Update Policy for Amplify's Auth Role and Unauth Role",
-    "githubUrl": "https://github.com/nikaera/serverless-amplify-auth",
-    "status": "active"
-  },
-  {
-    "name": "serverless-cloudformation-parameter-setter",
-    "description": "Set CloudFormation parameters when deploying.",
-    "githubUrl": "https://github.com/trek10inc/serverless-cloudformation-parameter-setter",
-    "status": "active"
-  },
-  {
-    "name": "serverless-alexa-skills",
-    "description": "Manage your Alexa Skills with Serverless Framework.",
-    "githubUrl": "https://github.com/marcy-terui/serverless-alexa-skills",
-    "status": "active"
-  },
-  {
-    "name": "serverless-plugin-chrome",
-    "description": "Plugin which bundles and ensures that Headless Chrome/Chromium is running when your AWS Lambda function handler is invoked.",
-    "githubUrl": "https://github.com/adieuadieu/serverless-chrome/tree/master/packages/serverless-plugin",
-    "status": "active"
-  },
-  {
-    "name": "serverless-ssm-fetch",
-    "description": "Sets \"AWS Systems Manager Parameter Store (SSM)\" parameters into functions' environment variables.",
-    "githubUrl": "https://github.com/gozup/serverless-ssm-fetch",
-    "status": "active"
-  },
-  {
-    "name": "serverless-custom-packaging-plugin",
-    "description": "Plugin to package your sourcecode using a custom target path inside the zip.",
-    "githubUrl": "https://github.com/hypoport/serverless-custom-packaging-plugin",
-    "status": "active"
-  },
-  {
-    "name": "kumologica-serverless-plugin",
-    "description": "Plugin to package and deploy Kumologica flow into AWS",
-    "githubUrl": "https://github.com/KumologicaHQ/kumologica-serverless-plugin"
-  },
-  {
-    "name": "serverless-apigw-binary",
-    "description": "Plugin to enable binary support in AWS API Gateway.",
-    "githubUrl": "https://github.com/maciejtreder/serverless-apigw-binary",
-    "status": "active"
-  },
-  {
-    "name": "serverless-certificate-creator",
-    "description": "This serverless plugin creates certificates that you need for your custom domains in API Gateway.",
-    "githubUrl": "https://github.com/schwamster/serverless-certificate-creator",
-    "status": "active"
-  },
-  {
-    "name": "serverless-apigator",
-    "description": "This serverless plugin enables you to write AWS lambda with typescript using Microgamma",
-    "githubUrl": "https://github.com/microgamma/microgamma",
-    "status": "active"
-  },
-  {
-    "name": "serverless-plugin-1password",
-    "description": "Serverless interface to 1Password data via the 1Password CLI",
-    "githubUrl": "https://github.com/kandsten/serverless-plugin-1password",
-    "status": "active"
-  },
-  {
-    "name": "serverless-log-filter-subscription",
-    "description": "This serverless plugin creates log filter subscription for all lambda functions configured in your projects serverless.yml",
-    "githubUrl": "https://github.com/schwamster/serverless-log-filter-subscription",
-    "status": "active"
-  },
-  {
-    "name": "serverless-domain-manager",
-    "description": "Serverless plugin for managing custom domains with API Gateways.",
-    "githubUrl": "https://github.com/amplify-education/serverless-domain-manager",
-    "status": "active"
-  },
-  {
-    "name": "serverless-log-forwarding",
-    "description": "Serverless plugin for forwarding CloudWatch logs to another Lambda function.",
-    "githubUrl": "https://github.com/amplify-education/serverless-log-forwarding",
-    "status": "active"
-  },
-  {
-    "name": "serverless-event-body-option",
-    "description": "Serverless plugin that provides the extra CLI option for the invoke command to support passing the HTTP body data.",
-    "githubUrl": "https://github.com/jubel-han/serverless-event-body-option",
-    "status": "active"
-  },
-  {
-    "name": "serverless-plugin-external-sns-events",
-    "description": "Add ability for functions to use existing or external SNS topics as an event source",
-    "githubUrl": "https://github.com/silvermine/serverless-plugin-external-sns-events",
-    "status": "active"
-  },
-  {
-    "name": "serverless-plugin-write-env-vars",
-    "description": "Write environment variables out to a file that is compatible with dotenv",
-    "githubUrl": "https://github.com/silvermine/serverless-plugin-write-env-vars",
-    "status": "active"
-  },
-  {
-    "name": "serverless-alexa-plugin",
-    "description": "Serverless plugin to support Alexa Lambda events",
-    "githubUrl": "https://github.com/rajington/serverless-alexa-plugin",
-    "status": "active"
-  },
-  {
-    "name": "serverless-build-plugin",
-    "description": "A Node.js focused build plugin for serverless.",
-    "githubUrl": "https://github.com/nfour/serverless-build-plugin",
-    "status": "active"
-  },
-  {
-    "name": "serverless-resources-env",
-    "description": "After Deploy, this plugin fetches cloudformation resource identifiers and sets them on AWS lambdas, and creates local .<state>-env file",
-    "githubUrl": "https://github.com/rurri/serverless-resources-env",
-    "status": "active"
-  },
-  {
-    "name": "serverless-event-constant-inputs",
-    "description": "Allows you to add constant inputs to events in Serverless 1.0. For more info see [constant values in Cloudwatch](https://aws.amazon.com/blogs/compute/simply-serverless-use-constant-values-in-cloudwatch-event-triggered-lambda-functions/)",
-    "githubUrl": "https://github.com/dittto/serverless-event-constant-inputs",
-    "status": "active"
-  },
-  {
-    "name": "serverless-kms-secrets",
-    "description": "Allows to easily encrypt and decrypt secrets using KMS from the serverless CLI",
-    "githubUrl": "https://github.com/SC5/serverless-kms-secrets",
-    "status": "active"
-  },
-  {
-    "name": "serverless-openapi-integration-helper",
-    "description": "Provides functionality to merge stage-dependent x-amazon-apigateway integrations into openApiSpecification files ",
-    "githubUrl": "https://github.com/yndlingsfar/serverless-openapi-integration-helper",
-    "status": "active"
-  },
-  {
-    "name": "serverless-plugin-stack-outputs",
-    "description": "Displays stack outputs for your serverless stacks when `sls info` is ran",
-    "githubUrl": "https://github.com/svdgraaf/serverless-plugin-stack-outputs",
-    "status": "active"
-  },
-  {
-    "name": "serverless-plugin-stage-variables",
-    "description": "Add stage variables for Serverless 1.x to ApiGateway, so you can use variables in your Lambda's",
-    "githubUrl": "https://github.com/svdgraaf/serverless-plugin-stage-variables",
-    "status": "active"
-  },
-  {
-    "name": "serverless-plugin-cloudwatch-sumologic",
-    "description": "Plugin which auto-subscribes a log delivery lambda function to lambda log groups created by serverless",
-    "githubUrl": "https://github.com/ACloudGuru/serverless-plugin-cloudwatch-sumologic",
-    "status": "active"
-  },
-  {
-    "name": "serverless-plugin-aws-alerts",
-    "description": "A Serverless plugin to easily add CloudWatch alarms to functions",
-    "githubUrl": "https://github.com/ACloudGuru/serverless-plugin-aws-alerts",
-    "status": "active"
-  },
-  {
-    "name": "serverless-plugin-package-dotenv-file",
-    "description": "A Serverless plugin to copy a .env file into the serverless package",
-    "githubUrl": "https://github.com/ACloudGuru/serverless-plugin-package-dotenv-file",
-    "status": "active"
-  },
-  {
-    "name": "serverless-command-line-event-args",
-    "description": "This module is Serverless Framework plugin. Event JSON passes to your Lambda function in commandline.",
-    "githubUrl": "https://github.com/horike37/serverless-command-line-event-args",
-    "status": "active"
-  },
-  {
-    "name": "serverless-dynamodb-client",
-    "description": "This Serverless 0.5.x plugin help you to call AWS Dynamodb SDK without switching between different dynamodb instances, whether you work with Dynamodb local or online in AWS.",
-    "githubUrl": "https://github.com/99xt/serverless-dynamodb-client",
-    "status": "active"
-  },
-  {
-    "name": "serverless-dynamodb-local",
-    "description": "Serverless Dynamodb Local Plugin - Allows to run dynamodb locally for serverless",
-    "githubUrl": "https://github.com/99xt/serverless-dynamodb-local",
-    "status": "active"
-  },
-  {
-    "name": "serverless-dynamodb-fixtures",
-    "description": "Serverless Dynamodb Fixtures - Allows to load data on DynamoDB tables",
-    "githubUrl": "https://github.com/chechu/serverless-dynamodb-fixtures",
-    "status": "active"
-  },
-  {
-    "name": "serverless-dynamo-stream-plugin",
-    "description": "Creates and connects DynamoDB streams for pre-existing tables with AWS Lambdas using Serverless.",
-    "githubUrl": "https://github.com/commandeer/open/tree/development/serverless-dynamo-stream-plugin",
-    "status": "active"
-  },
-  {
-    "name": "dynamo-data-transform",
-    "description": "Dynamo Data Transform is an easy to use data transformation tool for DynamoDB.",
-    "githubUrl": "https://github.com/jitsecurity/dynamo-data-transform",
-    "status": "active"
-  },
-  {
-    "name": "serverless-offline",
-    "description": "Emulate AWS λ and API Gateway locally when developing your Serverless project",
-    "githubUrl": "https://github.com/dherault/serverless-offline",
-    "status": "active"
-  },
-  {
-    "name": "serverless-offline-local-authorizers-plugin",
-    "description": "Serverless plugin for adding and mocking local authorizers when developing locally with serverless-offline.",
-    "githubUrl": "https://github.com/nlang/serverless-offline-local-authorizers-plugin",
-    "status": "active"
-  },
-  {
-    "name": "serverless-offline-ssm",
-    "description": "Read SSM parameters from a .env file instead of AWS",
-    "githubUrl": "https://github.com/janders223/serverless-offline-ssm",
-    "status": "active"
-  },
-  {
-    "name": "serverless-offline-direct-lambda",
-    "description": "Allow offline direct lambda-to-lambda interactions by exposing lambdas with no API Gateway event via HTTP.",
-    "githubUrl": "https://github.com/civicteam/serverless-offline-direct-lambda",
-    "status": "active"
-  },
-  {
-    "name": "serverless-offline-ses-v2",
-    "description": "Serverless plugin to run a local version of Amazon Simple Email Service (SES) supporting the V1 and V2 SendEmail and SendRawEmail APIs",
-    "githubUrl": "https://github.com/domdomegg/serverless-offline-ses-v2",
-    "status": "active"
-  },
-  {
-    "name": "serverless-offline-edge-lambda",
-    "description": "A plugin for the Serverless Framework that simulates the behavior of AWS CloudFront Edge Lambdas while developing offline",
-    "githubUrl": "https://github.com/evolv-ai/serverless-offline-edge-lambda",
-    "status": "active"
-  },
-  {
-    "name": "serverless-plugin-simulate",
-    "description": "Simulate AWS Lambda and API Gateway locally using Docker",
-    "githubUrl": "https://github.com/gertjvr/serverless-plugin-simulate",
-    "status": "active"
-  },
-  {
-    "name": "serverless-plugin-optimize",
-    "description": "Bundle with Browserify, transpile with Babel to ES5 and minify with Uglify your Serverless functions.",
-    "githubUrl": "https://github.com/FidelLimited/serverless-plugin-optimize",
-    "status": "active"
-  },
-  {
-    "name": "serverless-plugin-select",
-    "description": "Select which functions are to be deployed based on region and stage.",
-    "githubUrl": "https://github.com/FidelLimited/serverless-plugin-select",
-    "status": "active"
-  },
-  {
-    "name": "serverless-plugin-warmup",
-    "description": "Keep your lambdas warm during Winter.",
-    "githubUrl": "https://github.com/juanjoDiaz/serverless-plugin-warmup",
-    "status": "active"
-  },
-  {
-    "name": "serverless-plugin-aws-contributor-insights",
-    "description": "Support of AWS CloudWatch Contributor Insights",
-    "githubUrl": "https://github.com/kangcifong/serverless-plugin-aws-contributor-insights",
-    "status": "active"
-  },
-  {
-    "name": "serverless-plugin-browserify",
-    "description": "Speed up your node based lambda's",
-    "githubUrl": "https://github.com/doapp-ryanp/serverless-plugin-browserify",
-    "status": "inactive"
-  },
-  {
-    "name": "serverless-plugin-datadog",
-    "description": "Monitoring, tracing, and real-time metrics for your Lambda functions",
-    "githubUrl": "https://github.com/DataDog/serverless-plugin-datadog",
-    "status": "active"
-  },
-  {
-    "name": "serverless-plugin-diff",
-    "description": "Compares your local AWS CloudFormation templates against deployed ones.",
-    "githubUrl": "https://github.com/nicka/serverless-plugin-diff",
-    "status": "active"
-  },
-  {
-    "name": "serverless-run-function-plugin",
-    "description": "Run serverless function locally",
-    "githubUrl": "https://github.com/lithin/serverless-run-function-plugin",
-    "status": "active"
-  },
-  {
-    "name": "serverless-scriptable-plugin",
-    "description": "Customize Serverless behavior without writing a plugin.",
-    "githubUrl": "https://github.com/weixu365/serverless-scriptable-plugin",
-    "status": "active"
-  },
-  {
-    "name": "serverless-subscription-filter",
-    "description": "Serverless plugin to register subscription filter for Lambda logs. Register and pipe the logs of one lambda to another to process.",
-    "githubUrl": "https://github.com/blackevil245/serverless-subscription-filter",
-    "status": "active"
-  },
-  {
-    "name": "serverless-webpack",
-    "description": "Serverless plugin to bundle your lambdas with Webpack",
-    "githubUrl": "https://github.com/serverless-heaven/serverless-webpack",
-    "status": "active"
-  },
-  {
-    "name": "serverless-esbuild",
-    "description": "Serverless plugin to bundle JavaScript and TypeScript lambdas with esbuild - an extremely fast bundler and minifier",
-    "githubUrl": "https://github.com/floydspace/serverless-esbuild",
-    "status": "active"
-  },
-  {
-    "name": "serverless-wsgi",
-    "description": "Serverless plugin to deploy WSGI applications (Flask/Django/Pyramid etc.) and bundle Python packages",
-    "githubUrl": "https://github.com/logandk/serverless-wsgi",
-    "status": "active"
-  },
-  {
-    "name": "serverless-crypt",
-    "description": "Securing the secrets on Serverless Framework by AWS KMS encryption.",
-    "githubUrl": "https://github.com/marcy-terui/serverless-crypt",
-    "status": "active"
-  },
-  {
-    "name": "serverless-plugin-multiple-responses",
-    "description": "Enable multiple content-types for Response template ",
-    "githubUrl": "https://github.com/silvermine/serverless-plugin-multiple-responses",
-    "status": "active"
-  },
-  {
-    "name": "serverless-plugin-dot-template",
-    "description": "Generates output files based on Serverless variables and doT templates",
-    "githubUrl": "https://github.com/kandsten/serverless-plugin-dot-template",
-    "status": "active"
-  },
-  {
-    "name": "serverless-plugin-include-dependencies",
-    "description": "This is a Serverless plugin that should make your deployed functions smaller.",
-    "githubUrl": "https://github.com/dougmoscrop/serverless-plugin-include-dependencies",
-    "status": "active"
-  },
-  {
-    "name": "serverless-mocha-plugin",
-    "description": "A Serverless Plugin for the Serverless Framework which adds support for test-driven development using Mocha",
-    "githubUrl": "https://github.com/SC5/serverless-mocha-plugin",
-    "status": "active"
-  },
-  {
-    "name": "serverless-modular",
-    "description": "Helps you deploy and manage multiple features with single root serverless file",
-    "githubUrl": "https://github.com/aa2kb/serverless-modular",
-    "status": "active"
-  },
-  {
-    "name": "serverless-jest-plugin",
-    "description": "A Serverless Plugin for the Serverless Framework which adds support for test-driven development using Jest",
-    "githubUrl": "https://github.com/SC5/serverless-jest-plugin",
-    "status": "active"
-  },
-  {
-    "name": "serverless-plugin-cfauthorizer",
-    "description": "This plugin allows you to define your own API Gateway Authorizers as the Serverless CloudFormation resources and apply them to HTTP endpoints.",
-    "githubUrl": "https://github.com/SC5/serverless-plugin-cfauthorizer",
-    "status": "active"
-  },
-  {
-    "name": "serverless-cloudformation-changesets",
-    "description": "Natively deploy to CloudFormation via Change sets, instead of directly. Allowing you to queue changes, and safely require escalated roles for final deployment.",
-    "githubUrl": "https://github.com/trek10inc/serverless-cloudformation-changesets",
-    "status": "active"
-  },
-  {
-    "name": "raml-serverless",
-    "description": "Serverless plugin to work with RAML API spec documents",
-    "githubUrl": "https://github.com/andrewcurioso/raml-serverless",
-    "status": "active"
-  },
-  {
-    "name": "serverless-python-requirements",
-    "description": "Serverless plugin to bundle Python packages",
-    "githubUrl": "https://github.com/UnitedIncome/serverless-python-requirements",
-    "status": "active"
-  },
-  {
-    "name": "serverless-pydeps",
-    "description": "Serverless plugin to quickly automate Python dependencies",
-    "githubUrl": "https://github.com/CloudSnorkel/serverless-pydeps",
-    "status": "active"
-  },
-  {
-    "name": "serverless-ruby-layer",
-    "description": "A Serverless Plugin to auto deploy gems to AWS Layer using Gemfile",
-    "githubUrl": "https://github.com/navarasu/serverless-ruby-layer",
-    "status": "active"
-  },
-  {
-    "name": "serverless-multi-dotnet",
-    "description": "A serverless plugin to pack C# lambdas functions that are spread to multiple CS projects.",
-    "githubUrl": "https://github.com/tsibelman/serverless-multi-dotnet",
-    "status": "active"
-  },
-  {
-    "name": "serverless-dotnet",
-    "description": "A serverless plugin to run 'dotnet' commands as part of the deploy process",
-    "githubUrl": "https://github.com/fruffin/serverless-dotnet",
-    "status": "active"
-  },
-  {
-    "name": "serverless-enable-api-logs",
-    "description": "Enables Coudwatch logging for API Gateway events",
-    "githubUrl": "https://github.com/paulSambolin/serverless-enable-api-logs",
-    "status": "active"
-  },
-  {
-    "name": "serverless-python-individually",
-    "description": "A serverless framework plugin to install multiple lambda functions written in python",
-    "githubUrl": "https://github.com/cfchou/serverless-python-individually",
-    "status": "active"
-  },
-  {
-    "name": "serverless-plugin-subscription-filter",
-    "description": "A serverless plugin to register AWS CloudWatchLogs subscription filter",
-    "githubUrl": "https://github.com/tsub/serverless-plugin-subscription-filter",
-    "status": "active"
-  },
-  {
-    "name": "serverless-step-functions",
-    "description": "AWS Step Functions plugin for Serverless Framework",
-    "githubUrl": "https://github.com/serverless-operations/serverless-step-functions",
-    "status": "active"
-  },
-  {
-    "name": "serverless-lambda-layer-packager",
-    "description": "A Serverless plugin that allows you to maintain your normal project structure when developing Lambda Layers.",
-    "githubUrl": "https://github.com/bramhoven/serverless-lambda-layer-packager",
-    "status": "active"
-  },
-  {
-    "name": "serverless-apigateway-service-proxy",
-    "description": "This Serverless Framewrok plugin supports the AWS service proxy integration feature of API Gateway.",
-    "githubUrl": "https://github.com/horike37/serverless-apigateway-service-proxy",
-    "status": "active"
-  },
-  {
-    "name": "serverless-package-customizer",
-    "description": "This allows you to customize packaging system of the Serverless Framework from a command line.",
-    "githubUrl": "https://github.com/horike37/serverless-package-customizer",
-    "status": "active"
-  },
-  {
-    "name": "serverless-package-location-customizer",
-    "description": "A serverless plugin to allow custom S3Bucket and S3Key path when packaging Lambda Functions and Layers.",
-    "githubUrl": "https://github.com/cipri-p/serverless-package-location-customizer",
-    "status": "active"
-  },
-  {
-    "name": "serverless-plugin-scripts",
-    "description": "Add scripting capabilities to the Serverless Framework",
-    "githubUrl": "https://github.com/mvila/serverless-plugin-scripts",
-    "status": "active"
-  },
-  {
-    "name": "serverless-plugin-bind-deployment-id",
-    "description": "A Serverless plugin to bind the randomly generated deployment resource to your custom resources",
-    "githubUrl": "https://github.com/jacob-meacham/serverless-plugin-bind-deployment-id",
-    "status": "active"
-  },
-  {
-    "name": "serverless-plugin-git-variables",
-    "description": "A Serverless plugin to expose git variables (branch name, HEAD description, full commit hash) to your serverless services",
-    "githubUrl": "https://github.com/jacob-meacham/serverless-plugin-git-variables",
-    "status": "active"
-  },
-  {
-    "name": "serverless-plugin-graphiql",
-    "description": "A Serverless plugin to run a local http server for graphiql and your graphql handler",
-    "githubUrl": "https://github.com/bencooling/serverless-plugin-graphiql",
-    "status": "active"
-  },
-  {
-    "name": "serverless-coffeescript",
-    "description": "A Serverless plugin to compile your CoffeeScript into JavaScript at deployment",
-    "githubUrl": "https://github.com/duanefields/serverless-coffeescript",
-    "status": "active"
-  },
-  {
-    "name": "serverless-plugin-lambda-dead-letter",
-    "description": "A Serverless plugin that can configure a lambda with a dead letter queue or topic",
-    "githubUrl": "https://github.com/gmetzker/serverless-plugin-lambda-dead-letter",
-    "status": "active"
-  },
-  {
-    "name": "serverless-plugin-encode-env-var-objects",
-    "description": "Serverless plugin to encode any environment variable objects.",
-    "githubUrl": "https://github.com/yonomi/serverless-plugin-encode-env-var-objects",
-    "status": "active"
-  },
-  {
-    "name": "serverless-dir-config-plugin",
-    "description": "EXPERIMENTAL - Serverless plugin to load function and resource definitions from a directory.",
-    "githubUrl": "https://github.com/economysizegeek/serverless-dir-config-plugin",
-    "status": "active"
-  },
-  {
-    "name": "serverless-cljs-plugin",
-    "description": "Enables Clojurescript as an implementation language for Lambda handlers",
-    "githubUrl": "https://github.com/nervous-systems/serverless-cljs-plugin",
-    "status": "active"
-  },
-  {
-    "name": "serverless-apigateway-log-retention",
-    "description": "Control the retention of your AWS ApiGateway access logs and execution logs.",
-    "githubUrl": "https://github.com/dvla/serverless-apigateway-log-retention",
-    "status": "active"
-  },
-  {
-    "name": "serverless-prune-plugin",
-    "description": "Deletes old versions of functions from AWS, preserving recent and aliased versions",
-    "githubUrl": "https://github.com/claygregory/serverless-prune-plugin",
-    "status": "active"
-  },
-  {
-    "name": "@unly/serverless-env-copy-plugin",
-    "description": "Fetch environment variables and write it to a .env file - Maintained fork from https://github.com/Jimdo/serverless-dotenv",
-    "githubUrl": "https://github.com/UnlyEd/serverless-env-copy-plugin",
-    "status": "active"
-  },
-  {
-    "name": "@unly/serverless-plugin-dynamodb-backups",
-    "description": "Configure automated DynamoDB \"On-Demand\" backups and manage backups lifecycle, powered by AWS Lambda",
-    "githubUrl": "https://github.com/UnlyEd/serverless-plugin-dynamodb-backups",
-    "status": "active"
-  },
-  {
-    "name": "serverless-convention",
-    "description": "Dynamically import resources by defining a convention, split up your yml",
-    "githubUrl": "https://github.com/LeoPlatform/serverless-convention",
-    "status": "active"
-  },
-  {
-    "name": "serverless-openapi-documenter",
-    "description": "A plugin that creates a valid OpenAPI 3.0.X json or yaml schema as well as being able to output a Postman Collection v2 in json.",
-    "githubUrl": "https://github.com/JaredCE/serverless-openapi-documenter",
-    "status": "active"
-  },
-  {
-    "name": "serverless-offline-scheduler",
-    "description": "Runs scheduled functions offline while integrating with serverless-offline",
-    "githubUrl": "https://github.com/ajmath/serverless-offline-scheduler",
-    "status": "active"
-  },
-  {
-    "name": "serverless-aws-alias",
-    "description": "This plugin enables use of AWS aliases on Lambda functions.",
-    "githubUrl": "https://github.com/serverless-heaven/serverless-aws-alias",
-    "status": "active"
-  },
-  {
-    "name": "serverless-plugin-webpack",
-    "description": "A serverless plugin to automatically bundle your functions individually with webpack",
-    "githubUrl": "https://github.com/goldwasserexchange/serverless-plugin-webpack",
-    "status": "active"
-  },
-  {
-    "name": "serverless-secret-baker",
-    "description": "A Serverless Framework Plugin for secure, performant, and deterministic secret management.",
-    "githubUrl": "https://github.com/vacasaoss/serverless-secret-baker",
-    "status": "active"
-  },
-  {
-    "name": "serverless-sqs-fifo",
-    "description": "A serverless plugin to handle creation of sqs fifo queue's in aws (stop-gap)",
-    "githubUrl": "https://github.com/vortarian/serverless-sqs-fifo",
-    "status": "active"
-  },
-  {
-    "name": "serverless-sqs-alarms-plugin",
-    "description": "Wrapper to setup CloudWatch Alarms on SQS queue length",
-    "githubUrl": "https://github.com/sbstjn/serverless-sqs-alarms-plugin",
-    "status": "inactive"
-  },
-  {
-    "name": "serverless-dotenv",
-    "description": "Fetch environment variables and write it to a .env file",
-    "githubUrl": "https://github.com/Jimdo/serverless-dotenv",
-    "status": "active"
-  },
-  {
-    "name": "serverless-haskell",
-    "description": "Deploying Haskell applications to AWS Lambda with Serverless",
-    "githubUrl": "https://github.com/seek-oss/serverless-haskell",
-    "status": "active"
-  },
-  {
-    "name": "serverless-hooks-plugin",
-    "description": "Run arbitrary commands on any lifecycle event in serverless",
-    "githubUrl": "https://github.com/uswitch/serverless-hooks-plugin",
-    "status": "active"
-  },
-  {
-    "name": "serverless-offline-watcher",
-    "description": "Run arbitrary commands when files are changed while running serverless-offline",
-    "githubUrl": "https://github.com/domdomegg/serverless-offline-watcher",
-    "status": "active"
-  },
-  {
-    "name": "serverless-dynalite",
-    "description": "Run dynalite locally (no JVM, all JS) to simulate DynamoDB. Watch serverless.yml for table config updates.",
-    "githubUrl": "https://github.com/sdd/serverless-dynalite",
-    "status": "active"
-  },
-  {
-    "name": "serverless-apig-s3",
-    "description": "Serve static front-end content from S3 via the API Gateway and deploy client bundle to S3.",
-    "githubUrl": "https://github.com/sdd/serverless-apig-s3",
-    "status": "active"
-  },
-  {
-    "name": "serverless-plugin-typescript",
-    "description": "Serverless plugin for zero-config Typescript support.",
-    "githubUrl": "https://github.com/graphcool/serverless-plugin-typescript",
-    "status": "active"
-  },
-  {
-    "name": "serverless-parameters",
-    "description": "Add parameters to the generated cloudformation templates",
-    "githubUrl": "https://github.com/svdgraaf/serverless-parameters",
-    "status": "active"
-  },
-  {
-    "name": "serverless-git-commit-tracker",
-    "description": "Generates a version tracking file for web or API deployment containing the latest git commit version number, deployment stage, and date",
-    "githubUrl": "https://github.com/optimator999/serverless-git-commit-tracker",
-    "status": "active"
-  },
-  {
-    "name": "serverless-plugin-epsagon",
-    "description": "Distributed tracing that helps you monitor and troubleshoot your serverless applications.",
-    "githubUrl": "https://github.com/epsagon/serverless-plugin-epsagon",
-    "status": "active"
-  },
-  {
-    "name": "serverless-dynamodb-ttl",
-    "description": "Configure DynamoDB TTL in serverless.yml (until CloudFormation supports this).",
-    "githubUrl": "https://github.com/Jimdo/serverless-dynamodb-ttl",
-    "status": "active"
-  },
-  {
-    "name": "serverless-api-stage",
-    "description": "Serverless API Stage plugin, enables stage variables and logging for AWS API Gateway.",
-    "githubUrl": "https://github.com/leftclickben/serverless-api-stage",
-    "status": "active"
-  },
-  {
-    "name": "serverless-plugin-lambda-insights",
-    "description": "A Serverless Framework Plugin allowing to enable Lambda Insights.",
-    "githubUrl": "https://github.com/awslabs/serverless-plugin-lambda-insights",
-    "status": "active"
-  },
+  }, {
+  "name": "serverless-plugin-apollo-graphql-federation",
+  "description": "A Serverless Framework that uploads a graphql schema to the Apollo Platform managed federation service",
+  "githubUrl": "https://github.com/Imran99/serverless-plugin-apollo-graphql-federation",
+  "status": "active"
+}, {
+  "name": "serverless-plugin-modularize",
+  "description": "Modularize your serverless definitions",
+  "githubUrl": "https://github.com/icarus-sullivan/serverless-plugin-modularize",
+  "status": "active"
+}, {
+  "name": "@stratiformdigital/serverless-online",
+  "description": "Faster lambda development in AWS through hot deploys and streaming logs.",
+  "githubUrl": "https://github.com/stratiformdigital/serverless-online",
+  "status": "active"
+}, {
+  "name": "@stratiformdigital/serverless-iam-helper",
+  "description": "Applies IAM Path and PermissionsBoundary settings in hard to reach places.",
+  "githubUrl": "https://github.com/stratiformdigital/serverless-iam-helper",
+  "status": "active"
+}, {
+  "name": "@stratiformdigital/serverless-idempotency-helper",
+  "description": "Helps make lambda deployments idempotent",
+  "githubUrl": "https://github.com/stratiformdigital/serverless-idempotency-helper",
+  "status": "active"
+}, {
+  "name": "@stratiformdigital/serverless-s3-security-helper",
+  "description": "Sets security minded settings on s3 buckets, including sls deployment buckets",
+  "githubUrl": "https://github.com/stratiformdigital/serverless-s3-security-helper",
+  "status": "active"
+}, {
+  "name": "serverless-provisioned-concurrency-autoscaling",
+  "description": "Serverless Plugin for AWS Lambda Provisioned Concurrency Auto Scaling configuration",
+  "githubUrl": "https://github.com/neiman-marcus/serverless-provisioned-concurrency-autoscaling",
+  "status": "active"
+}, {
+  "name": "serverless-localstack",
+  "description": "Serverless plugin for LocalStack - a fully functional local AWS cloud stack. Develop and test your cloud & Serverless apps offline!",
+  "githubUrl": "https://github.com/LocalStack/serverless-localstack",
+  "status": "active"
+}, {
+  "name": "serverless-commercetools-plugin",
+  "description": "Serverless framework plugin that registers the deployed function as a commercetools API Extension or attaches it to a Subscription.",
+  "githubUrl": "https://github.com/commercetools/serverless-commercetools-plugin",
+  "status": "active"
+}, {
+  "name": "serverless-plugin-test-helper",
+  "description": "Makes it easier to end-to-end test deployed deployed services by saving CloudFormation Stack Outputs locally and exposing values via a simple Node.js library",
+  "githubUrl": "https://github.com/manwaring/serverless-plugin-test-helper",
+  "status": "active"
+}, {
+  "name": "serverless-plugin-dart",
+  "description": "Deploy Dart applications to AWS Lambda",
+  "githubUrl": "https://github.com/katallaxie/serverless-dart",
+  "status": "active"
+}, {
+  "name": "serverless-scaleway-serverless",
+  "description": "This plugin enables support for Scaleway Serverless Functions and Serverless Containers betas within the Serverless Framework",
+  "githubUrl": "https://github.com/scaleway/serverless-scaleway-functions",
+  "status": "active"
+}, {
+  "name": "serverless-plugin-iam-checker",
+  "description": "Helps automate security controls by preventing overly broad IAM permissions via customizable rules for both actions and resource references. Ships with restrictive defaults and supports custom rule configurations via serverless.yml and environment variables",
+  "githubUrl": "https://github.com/manwaring/serverless-plugin-iam-checker",
+  "status": "active"
+}, {
+  "name": "serverless-plugin-layer-manager",
+  "description": "Plugin for improved AWS Lambda layer management, including install hooks, export options and improved retain support",
+  "githubUrl": "https://github.com/henhal/serverless-plugin-layer-manager",
+  "status": "active"
+}, {
+  "name": "serverless-plugin-lambda-edge",
+  "description": "Plugin for Lambda@Edge, just associating your Lambda function with existing CloudFront distribution via AWS SDK",
+  "githubUrl": "https://github.com/isudzumi/serverless-plugin-lambda-edge",
+  "status": "active"
+}, {
+  "name": "serverless-export-outputs",
+  "description": "A Serverless plugin for exporting AWS stack outputs to a file",
+  "githubUrl": "https://github.com/honarpour/serverless-export-outputs",
+  "status": "active"
+}, {
+  "name": "serverless-plugin-apigateway-sqs",
+  "description": "Plugin that creates an AWS APIGateway resource to connect to an AWS Simple Queue Service (SQS) without the use of a lambda.",
+  "githubUrl": "https://github.com/CodeRecipe-dev/serverless-apigw-sqs-plugin",
+  "status": "active"
+}, {
+  "name": "serverless-mongodb-local",
+  "description": "Serverless MongoDB local plugin",
+  "githubUrl": "https://github.com/bealearts/serverless-mongodb-local",
+  "status": "active"
+}, {
+  "name": "serverless-plugin-utils",
+  "description": "A collection of serverless framework utilities",
+  "githubUrl": "https://github.com/icarus-sullivan/serverless-plugin-utils",
+  "status": "active"
+}, {
+  "name": "serverless-layers",
+  "description": "How to reduce drastically lambda size",
+  "githubUrl": "https://github.com/agutoli/serverless-layers",
+  "status": "active"
+}, {
+  "name": "mfa-serverless-plugin",
+  "description": "A simple plugin for deployment accounts with MFA",
+  "githubUrl": "https://github.com/alikian/mfa-serverless-plugin",
+  "status": "active"
+}, {
+  "name": "serverless-ini-env",
+  "description": "Nice Serverless plugin to setup environment variables with ini file",
+  "githubUrl": "https://github.com/agutoli/serverless-ini-env",
+  "status": "active"
+}, {
+  "name": "serverless-websockets-plugin",
+  "description": "Websocket support for Serverless Framework on AWS",
+  "githubUrl": "https://github.com/serverless/serverless-websockets-plugin",
+  "status": "active"
+}, {
+  "name": "serverless-resource-policy",
+  "description": "Creates a whitelist of IP or CIDR addresses using serverless resource policies",
+  "githubUrl": "https://github.com/HubSpotWebTeam/serverless-resource-policy",
+  "status": "active"
+}, {
+  "name": "serverless-plugin-vault-v2",
+  "description": "Simplify integration between serverless and vault to storage environments variables",
+  "githubUrl": "https://github.com/eliasjcjunior/serverless-plugin-vault-v2",
+  "status": "active"
+}, {
+  "name": "serverless-plugin-powertools",
+  "description": "Serverless plugin adding several variable tools, resolvers, and commands",
+  "githubUrl": "https://github.com/whardier/serverless-plugin-powertools",
+  "status": "active"
+}, {
+  "name": "serverless-justauthenticateme-plugin",
+  "description": "Use JustAuthenticateMe to easily authenticate users before hitting your lambdas",
+  "githubUrl": "https://github.com/CoalesceSoftware/serverless-justauthenticateme-plugin",
+  "status": "active"
+}, {
+  "name": "serverless-openapi-plugin",
+  "description": "Serverless plugin to generate serverless API architecture from OpenAPI definition.",
+  "githubUrl": "https://github.com/jaumard/serverless-openapi-plugin",
+  "status": "active"
+}, {
+  "name": "serverless-dotenv-plugin",
+  "description": "Preload environment variables from `.env` into serverless.",
+  "githubUrl": "https://github.com/infrontlabs/serverless-dotenv-plugin",
+  "status": "active"
+}, {
+  "name": "serverless-disable-request-validators",
+  "description": "Serverless v2/v3 plugin to disable API Gateway request validators.",
+  "githubUrl": "https://github.com/jweyrich/serverless-disable-request-validators",
+  "status": "active"
+}, {
+  "name": "serverless-default-aws-resource-attributes",
+  "description": "Set default attributes a given CloudFormation resource should have based on type.",
+  "githubUrl": "https://github.com/neverendingqs/serverless-default-aws-resource-attributes",
+  "status": "active"
+}, {
+  "name": "serverless-stack-policy-by-resource-type",
+  "description": "Serverless Framework plugin for automatically populating CloudFormation stack policy statements by resource type.",
+  "githubUrl": "https://github.com/neverendingqs/serverless-stack-policy-by-resource-type",
+  "status": "active"
+}, {
+  "name": "serverless-print-resolved-plugin",
+  "description": "Generate a copy of serverless.yml with all variables resolved.",
+  "githubUrl": "https://github.com/neverendingqs/serverless-print-resolved-plugin",
+  "status": "active"
+}, {
+  "name": "serverless-discovery-plugin",
+  "description": "A serverless plugin to register AWS micro-service endpoints with a discovery service at serverless deploy or serverless remove time.",
+  "githubUrl": "https://github.com/aregier/serverless-discovery-plugin",
+  "status": "active"
+}, {
+  "name": "fullstack-serverless",
+  "description": "A Serverless plugin to create an AWS CloudFront distribution that serves static web content from S3 and routes API traffic to API Gateway.",
+  "githubUrl": "https://github.com/MadSkills-io/fullstack-serverless",
+  "status": "active"
+}, {
+  "name": "serverless-finch",
+  "description": "A Serverless plugin to deploy static website assets to AWS S3.",
+  "githubUrl": "https://github.com/fernando-mc/serverless-finch",
+  "status": "active"
+}, {
+  "name": "serverless-appsync-plugin",
+  "description": "Serverless Plugin to deploy AppSync GraphQL API",
+  "githubUrl": "https://github.com/sid88in/serverless-appsync-plugin",
+  "status": "active"
+}, {
+  "name": "serverless-appsync-simulator",
+  "description": "Offline support for serverless-appsync-plugin",
+  "githubUrl": "https://github.com/bboure/serverless-appsync-simulator",
+  "status": "active"
+}, {
+  "name": "serverless-remote-json-envs",
+  "description": "Allows to use plain JSON files in remote locations being parsed as environment variables in lambda",
+  "githubUrl": "https://github.com/juancarestre/serverless-remote-json-envs",
+  "status": "active"
+}, {
+  "name": "serverless-plugin-tag-cloud-watch-logs",
+  "description": "Small serverless plugin providing a way to add tags to CloudWatch resources",
+  "githubUrl": "https://github.com/pretty-fun-therapy/serverless-plugin-tag-cloud-watch-logs",
+  "status": "active"
+}, {
+  "name": "serverless-appsync-offline",
+  "description": "Serverless Plugin to run AWS AppSync GraphQL API localy with dynamoDB and lambda resolvers",
+  "githubUrl": "https://github.com/aheissenberger/serverless-appsync-offline",
+  "status": "active"
+}, {
+  "name": "aws-amplify-serverless-plugin",
+  "description": "Generate client-side configuration files for the AWS Amplify library based on your deployed Serverless backend",
+  "githubUrl": "https://github.com/awslabs/aws-amplify-serverless-plugin",
+  "status": "active"
+}, {
+  "name": "serverless-amplify-auth",
+  "description": "Update Policy for Amplify's Auth Role and Unauth Role",
+  "githubUrl": "https://github.com/nikaera/serverless-amplify-auth",
+  "status": "active"
+}, {
+  "name": "serverless-cloudformation-parameter-setter",
+  "description": "Set CloudFormation parameters when deploying.",
+  "githubUrl": "https://github.com/trek10inc/serverless-cloudformation-parameter-setter",
+  "status": "active"
+}, {
+  "name": "serverless-alexa-skills",
+  "description": "Manage your Alexa Skills with Serverless Framework.",
+  "githubUrl": "https://github.com/marcy-terui/serverless-alexa-skills",
+  "status": "active"
+}, {
+  "name": "serverless-plugin-chrome",
+  "description": "Plugin which bundles and ensures that Headless Chrome/Chromium is running when your AWS Lambda function handler is invoked.",
+  "githubUrl": "https://github.com/adieuadieu/serverless-chrome/tree/master/packages/serverless-plugin",
+  "status": "active"
+}, {
+  "name": "serverless-ssm-fetch",
+  "description": "Sets \"AWS Systems Manager Parameter Store (SSM)\" parameters into functions' environment variables.",
+  "githubUrl": "https://github.com/gozup/serverless-ssm-fetch",
+  "status": "active"
+}, {
+  "name": "serverless-custom-packaging-plugin",
+  "description": "Plugin to package your sourcecode using a custom target path inside the zip.",
+  "githubUrl": "https://github.com/hypoport/serverless-custom-packaging-plugin",
+  "status": "active"
+}, {
+  "name": "kumologica-serverless-plugin",
+  "description": "Plugin to package and deploy Kumologica flow into AWS",
+  "githubUrl": "https://github.com/KumologicaHQ/kumologica-serverless-plugin"
+}, {
+  "name": "serverless-apigw-binary",
+  "description": "Plugin to enable binary support in AWS API Gateway.",
+  "githubUrl": "https://github.com/maciejtreder/serverless-apigw-binary",
+  "status": "active"
+}, {
+  "name": "serverless-certificate-creator",
+  "description": "This serverless plugin creates certificates that you need for your custom domains in API Gateway.",
+  "githubUrl": "https://github.com/schwamster/serverless-certificate-creator",
+  "status": "active"
+}, {
+  "name": "serverless-apigator",
+  "description": "This serverless plugin enables you to write AWS lambda with typescript using Microgamma",
+  "githubUrl": "https://github.com/microgamma/microgamma",
+  "status": "active"
+}, {
+  "name": "serverless-plugin-1password",
+  "description": "Serverless interface to 1Password data via the 1Password CLI",
+  "githubUrl": "https://github.com/kandsten/serverless-plugin-1password",
+  "status": "active"
+}, {
+  "name": "serverless-log-filter-subscription",
+  "description": "This serverless plugin creates log filter subscription for all lambda functions configured in your projects serverless.yml",
+  "githubUrl": "https://github.com/schwamster/serverless-log-filter-subscription",
+  "status": "active"
+}, {
+  "name": "serverless-domain-manager",
+  "description": "Serverless plugin for managing custom domains with API Gateways.",
+  "githubUrl": "https://github.com/amplify-education/serverless-domain-manager",
+  "status": "active"
+}, {
+  "name": "serverless-log-forwarding",
+  "description": "Serverless plugin for forwarding CloudWatch logs to another Lambda function.",
+  "githubUrl": "https://github.com/amplify-education/serverless-log-forwarding",
+  "status": "active"
+}, {
+  "name": "serverless-event-body-option",
+  "description": "Serverless plugin that provides the extra CLI option for the invoke command to support passing the HTTP body data.",
+  "githubUrl": "https://github.com/jubel-han/serverless-event-body-option",
+  "status": "active"
+}, {
+  "name": "serverless-plugin-external-sns-events",
+  "description": "Add ability for functions to use existing or external SNS topics as an event source",
+  "githubUrl": "https://github.com/silvermine/serverless-plugin-external-sns-events",
+  "status": "active"
+}, {
+  "name": "serverless-plugin-write-env-vars",
+  "description": "Write environment variables out to a file that is compatible with dotenv",
+  "githubUrl": "https://github.com/silvermine/serverless-plugin-write-env-vars",
+  "status": "active"
+}, {
+  "name": "serverless-alexa-plugin",
+  "description": "Serverless plugin to support Alexa Lambda events",
+  "githubUrl": "https://github.com/rajington/serverless-alexa-plugin",
+  "status": "active"
+}, {
+  "name": "serverless-build-plugin",
+  "description": "A Node.js focused build plugin for serverless.",
+  "githubUrl": "https://github.com/nfour/serverless-build-plugin",
+  "status": "active"
+}, {
+  "name": "serverless-resources-env",
+  "description": "After Deploy, this plugin fetches cloudformation resource identifiers and sets them on AWS lambdas, and creates local .<state>-env file",
+  "githubUrl": "https://github.com/rurri/serverless-resources-env",
+  "status": "active"
+}, {
+  "name": "serverless-event-constant-inputs",
+  "description": "Allows you to add constant inputs to events in Serverless 1.0. For more info see [constant values in Cloudwatch](https://aws.amazon.com/blogs/compute/simply-serverless-use-constant-values-in-cloudwatch-event-triggered-lambda-functions/)",
+  "githubUrl": "https://github.com/dittto/serverless-event-constant-inputs",
+  "status": "active"
+}, {
+  "name": "serverless-kms-secrets",
+  "description": "Allows to easily encrypt and decrypt secrets using KMS from the serverless CLI",
+  "githubUrl": "https://github.com/SC5/serverless-kms-secrets",
+  "status": "active"
+}, {
+  "name": "serverless-openapi-integration-helper",
+  "description": "Provides functionality to merge stage-dependent x-amazon-apigateway integrations into openApiSpecification files ",
+  "githubUrl": "https://github.com/yndlingsfar/serverless-openapi-integration-helper",
+  "status": "active"
+}, {
+  "name": "serverless-plugin-stack-outputs",
+  "description": "Displays stack outputs for your serverless stacks when `sls info` is ran",
+  "githubUrl": "https://github.com/svdgraaf/serverless-plugin-stack-outputs",
+  "status": "active"
+}, {
+  "name": "serverless-plugin-stage-variables",
+  "description": "Add stage variables for Serverless 1.x to ApiGateway, so you can use variables in your Lambda's",
+  "githubUrl": "https://github.com/svdgraaf/serverless-plugin-stage-variables",
+  "status": "active"
+}, {
+  "name": "serverless-plugin-cloudwatch-sumologic",
+  "description": "Plugin which auto-subscribes a log delivery lambda function to lambda log groups created by serverless",
+  "githubUrl": "https://github.com/ACloudGuru/serverless-plugin-cloudwatch-sumologic",
+  "status": "active"
+}, {
+  "name": "serverless-plugin-aws-alerts",
+  "description": "A Serverless plugin to easily add CloudWatch alarms to functions",
+  "githubUrl": "https://github.com/ACloudGuru/serverless-plugin-aws-alerts",
+  "status": "active"
+}, {
+  "name": "serverless-plugin-package-dotenv-file",
+  "description": "A Serverless plugin to copy a .env file into the serverless package",
+  "githubUrl": "https://github.com/ACloudGuru/serverless-plugin-package-dotenv-file",
+  "status": "active"
+}, {
+  "name": "serverless-command-line-event-args",
+  "description": "This module is Serverless Framework plugin. Event JSON passes to your Lambda function in commandline.",
+  "githubUrl": "https://github.com/horike37/serverless-command-line-event-args",
+  "status": "active"
+}, {
+  "name": "serverless-dynamodb-client",
+  "description": "This Serverless 0.5.x plugin help you to call AWS Dynamodb SDK without switching between different dynamodb instances, whether you work with Dynamodb local or online in AWS.",
+  "githubUrl": "https://github.com/99xt/serverless-dynamodb-client",
+  "status": "active"
+}, {
+  "name": "serverless-dynamodb-local",
+  "description": "Serverless Dynamodb Local Plugin - Allows to run dynamodb locally for serverless",
+  "githubUrl": "https://github.com/99xt/serverless-dynamodb-local",
+  "status": "active"
+}, {
+  "name": "serverless-dynamodb-fixtures",
+  "description": "Serverless Dynamodb Fixtures - Allows to load data on DynamoDB tables",
+  "githubUrl": "https://github.com/chechu/serverless-dynamodb-fixtures",
+  "status": "active"
+}, {
+  "name": "serverless-dynamo-stream-plugin",
+  "description": "Creates and connects DynamoDB streams for pre-existing tables with AWS Lambdas using Serverless.",
+  "githubUrl": "https://github.com/commandeer/open/tree/development/serverless-dynamo-stream-plugin",
+  "status": "active"
+}, {
+  "name": "dynamo-data-transform",
+  "description": "Dynamo Data Transform is an easy to use data transformation tool for DynamoDB.",
+  "githubUrl": "https://github.com/jitsecurity/dynamo-data-transform",
+  "status": "active"
+}, {
+  "name": "serverless-offline",
+  "description": "Emulate AWS λ and API Gateway locally when developing your Serverless project",
+  "githubUrl": "https://github.com/dherault/serverless-offline",
+  "status": "active"
+}, {
+  "name": "serverless-offline-local-authorizers-plugin",
+  "description": "Serverless plugin for adding and mocking local authorizers when developing locally with serverless-offline.",
+  "githubUrl": "https://github.com/nlang/serverless-offline-local-authorizers-plugin",
+  "status": "active"
+}, {
+  "name": "serverless-offline-ssm",
+  "description": "Read SSM parameters from a .env file instead of AWS",
+  "githubUrl": "https://github.com/janders223/serverless-offline-ssm",
+  "status": "active"
+}, {
+  "name": "serverless-offline-direct-lambda",
+  "description": "Allow offline direct lambda-to-lambda interactions by exposing lambdas with no API Gateway event via HTTP.",
+  "githubUrl": "https://github.com/civicteam/serverless-offline-direct-lambda",
+  "status": "active"
+}, {
+  "name": "serverless-offline-ses-v2",
+  "description": "Serverless plugin to run a local version of Amazon Simple Email Service (SES) supporting the V1 and V2 SendEmail and SendRawEmail APIs",
+  "githubUrl": "https://github.com/domdomegg/serverless-offline-ses-v2",
+  "status": "active"
+}, {
+  "name": "serverless-offline-edge-lambda",
+  "description": "A plugin for the Serverless Framework that simulates the behavior of AWS CloudFront Edge Lambdas while developing offline",
+  "githubUrl": "https://github.com/evolv-ai/serverless-offline-edge-lambda",
+  "status": "active"
+}, {
+  "name": "serverless-plugin-simulate",
+  "description": "Simulate AWS Lambda and API Gateway locally using Docker",
+  "githubUrl": "https://github.com/gertjvr/serverless-plugin-simulate",
+  "status": "active"
+}, {
+  "name": "serverless-plugin-optimize",
+  "description": "Bundle with Browserify, transpile with Babel to ES5 and minify with Uglify your Serverless functions.",
+  "githubUrl": "https://github.com/FidelLimited/serverless-plugin-optimize",
+  "status": "active"
+}, {
+  "name": "serverless-plugin-select",
+  "description": "Select which functions are to be deployed based on region and stage.",
+  "githubUrl": "https://github.com/FidelLimited/serverless-plugin-select",
+  "status": "active"
+}, {
+  "name": "serverless-plugin-warmup",
+  "description": "Keep your lambdas warm during Winter.",
+  "githubUrl": "https://github.com/juanjoDiaz/serverless-plugin-warmup",
+  "status": "active"
+}, {
+  "name": "serverless-plugin-aws-contributor-insights",
+  "description": "Support of AWS CloudWatch Contributor Insights",
+  "githubUrl": "https://github.com/kangcifong/serverless-plugin-aws-contributor-insights",
+  "status": "active"
+}, {
+  "name": "serverless-plugin-browserify",
+  "description": "Speed up your node based lambda's",
+  "githubUrl": "https://github.com/doapp-ryanp/serverless-plugin-browserify",
+  "status": "inactive"
+}, {
+  "name": "serverless-plugin-datadog",
+  "description": "Monitoring, tracing, and real-time metrics for your Lambda functions",
+  "githubUrl": "https://github.com/DataDog/serverless-plugin-datadog",
+  "status": "active"
+}, {
+  "name": "serverless-plugin-diff",
+  "description": "Compares your local AWS CloudFormation templates against deployed ones.",
+  "githubUrl": "https://github.com/nicka/serverless-plugin-diff",
+  "status": "active"
+}, {
+  "name": "serverless-run-function-plugin",
+  "description": "Run serverless function locally",
+  "githubUrl": "https://github.com/lithin/serverless-run-function-plugin",
+  "status": "active"
+}, {
+  "name": "serverless-scriptable-plugin",
+  "description": "Customize Serverless behavior without writing a plugin.",
+  "githubUrl": "https://github.com/weixu365/serverless-scriptable-plugin",
+  "status": "active"
+}, {
+  "name": "serverless-subscription-filter",
+  "description": "Serverless plugin to register subscription filter for Lambda logs. Register and pipe the logs of one lambda to another to process.",
+  "githubUrl": "https://github.com/blackevil245/serverless-subscription-filter",
+  "status": "active"
+}, {
+  "name": "serverless-webpack",
+  "description": "Serverless plugin to bundle your lambdas with Webpack",
+  "githubUrl": "https://github.com/serverless-heaven/serverless-webpack",
+  "status": "active"
+}, {
+  "name": "serverless-esbuild",
+  "description": "Serverless plugin to bundle JavaScript and TypeScript lambdas with esbuild - an extremely fast bundler and minifier",
+  "githubUrl": "https://github.com/floydspace/serverless-esbuild",
+  "status": "active"
+}, {
+  "name": "serverless-wsgi",
+  "description": "Serverless plugin to deploy WSGI applications (Flask/Django/Pyramid etc.) and bundle Python packages",
+  "githubUrl": "https://github.com/logandk/serverless-wsgi",
+  "status": "active"
+}, {
+  "name": "serverless-crypt",
+  "description": "Securing the secrets on Serverless Framework by AWS KMS encryption.",
+  "githubUrl": "https://github.com/marcy-terui/serverless-crypt",
+  "status": "active"
+}, {
+  "name": "serverless-plugin-multiple-responses",
+  "description": "Enable multiple content-types for Response template ",
+  "githubUrl": "https://github.com/silvermine/serverless-plugin-multiple-responses",
+  "status": "active"
+}, {
+  "name": "serverless-plugin-dot-template",
+  "description": "Generates output files based on Serverless variables and doT templates",
+  "githubUrl": "https://github.com/kandsten/serverless-plugin-dot-template",
+  "status": "active"
+}, {
+  "name": "serverless-plugin-include-dependencies",
+  "description": "This is a Serverless plugin that should make your deployed functions smaller.",
+  "githubUrl": "https://github.com/dougmoscrop/serverless-plugin-include-dependencies",
+  "status": "active"
+}, {
+  "name": "serverless-mocha-plugin",
+  "description": "A Serverless Plugin for the Serverless Framework which adds support for test-driven development using Mocha",
+  "githubUrl": "https://github.com/SC5/serverless-mocha-plugin",
+  "status": "active"
+}, {
+  "name": "serverless-modular",
+  "description": "Helps you deploy and manage multiple features with single root serverless file",
+  "githubUrl": "https://github.com/aa2kb/serverless-modular",
+  "status": "active"
+}, {
+  "name": "serverless-jest-plugin",
+  "description": "A Serverless Plugin for the Serverless Framework which adds support for test-driven development using Jest",
+  "githubUrl": "https://github.com/SC5/serverless-jest-plugin",
+  "status": "active"
+}, {
+  "name": "serverless-plugin-cfauthorizer",
+  "description": "This plugin allows you to define your own API Gateway Authorizers as the Serverless CloudFormation resources and apply them to HTTP endpoints.",
+  "githubUrl": "https://github.com/SC5/serverless-plugin-cfauthorizer",
+  "status": "active"
+}, {
+  "name": "serverless-cloudformation-changesets",
+  "description": "Natively deploy to CloudFormation via Change sets, instead of directly. Allowing you to queue changes, and safely require escalated roles for final deployment.",
+  "githubUrl": "https://github.com/trek10inc/serverless-cloudformation-changesets",
+  "status": "active"
+}, {
+  "name": "raml-serverless",
+  "description": "Serverless plugin to work with RAML API spec documents",
+  "githubUrl": "https://github.com/andrewcurioso/raml-serverless",
+  "status": "active"
+}, {
+  "name": "serverless-python-requirements",
+  "description": "Serverless plugin to bundle Python packages",
+  "githubUrl": "https://github.com/UnitedIncome/serverless-python-requirements",
+  "status": "active"
+}, {
+  "name": "serverless-pydeps",
+  "description": "Serverless plugin to quickly automate Python dependencies",
+  "githubUrl": "https://github.com/CloudSnorkel/serverless-pydeps",
+  "status": "active"
+}, {
+  "name": "serverless-ruby-layer",
+  "description": "A Serverless Plugin to auto deploy gems to AWS Layer using Gemfile",
+  "githubUrl": "https://github.com/navarasu/serverless-ruby-layer",
+  "status": "active"
+}, {
+  "name": "serverless-multi-dotnet",
+  "description": "A serverless plugin to pack C# lambdas functions that are spread to multiple CS projects.",
+  "githubUrl": "https://github.com/tsibelman/serverless-multi-dotnet",
+  "status": "active"
+},{
+  "name": "serverless-dotnet",
+  "description": "A serverless plugin to run 'dotnet' commands as part of the deploy process",
+  "githubUrl": "https://github.com/fruffin/serverless-dotnet",
+  "status": "active"
+}, {
+  "name": "serverless-enable-api-logs",
+  "description": "Enables Coudwatch logging for API Gateway events",
+  "githubUrl": "https://github.com/paulSambolin/serverless-enable-api-logs",
+  "status": "active"
+}, {
+  "name": "serverless-python-individually",
+  "description": "A serverless framework plugin to install multiple lambda functions written in python",
+  "githubUrl": "https://github.com/cfchou/serverless-python-individually",
+  "status": "active"
+}, {
+  "name": "serverless-plugin-subscription-filter",
+  "description": "A serverless plugin to register AWS CloudWatchLogs subscription filter",
+  "githubUrl": "https://github.com/tsub/serverless-plugin-subscription-filter",
+  "status": "active"
+}, {
+  "name": "serverless-step-functions",
+  "description": "AWS Step Functions plugin for Serverless Framework",
+  "githubUrl": "https://github.com/serverless-operations/serverless-step-functions",
+  "status": "active"
+}, {
+  "name": "serverless-lambda-layer-packager",
+  "description": "A Serverless plugin that allows you to maintain your normal project structure when developing Lambda Layers.",
+  "githubUrl": "https://github.com/bramhoven/serverless-lambda-layer-packager",
+  "status": "active"
+}, {
+  "name": "serverless-apigateway-service-proxy",
+  "description": "This Serverless Framewrok plugin supports the AWS service proxy integration feature of API Gateway.",
+  "githubUrl": "https://github.com/horike37/serverless-apigateway-service-proxy",
+  "status": "active"
+}, {
+  "name": "serverless-package-customizer",
+  "description": "This allows you to customize packaging system of the Serverless Framework from a command line.",
+  "githubUrl": "https://github.com/horike37/serverless-package-customizer",
+  "status": "active"
+}, {
+  "name": "serverless-package-location-customizer",
+  "description": "A serverless plugin to allow custom S3Bucket and S3Key path when packaging Lambda Functions and Layers.",
+  "githubUrl": "https://github.com/cipri-p/serverless-package-location-customizer",
+  "status": "active"
+}, {
+  "name": "serverless-plugin-scripts",
+  "description": "Add scripting capabilities to the Serverless Framework",
+  "githubUrl": "https://github.com/mvila/serverless-plugin-scripts",
+  "status": "active"
+}, {
+  "name": "serverless-plugin-bind-deployment-id",
+  "description": "A Serverless plugin to bind the randomly generated deployment resource to your custom resources",
+  "githubUrl": "https://github.com/jacob-meacham/serverless-plugin-bind-deployment-id",
+  "status": "active"
+}, {
+  "name": "serverless-plugin-git-variables",
+  "description": "A Serverless plugin to expose git variables (branch name, HEAD description, full commit hash) to your serverless services",
+  "githubUrl": "https://github.com/jacob-meacham/serverless-plugin-git-variables",
+  "status": "active"
+}, {
+  "name": "serverless-plugin-graphiql",
+  "description": "A Serverless plugin to run a local http server for graphiql and your graphql handler",
+  "githubUrl": "https://github.com/bencooling/serverless-plugin-graphiql",
+  "status": "active"
+}, {
+  "name": "serverless-coffeescript",
+  "description": "A Serverless plugin to compile your CoffeeScript into JavaScript at deployment",
+  "githubUrl": "https://github.com/duanefields/serverless-coffeescript",
+  "status": "active"
+}, {
+  "name": "serverless-plugin-lambda-dead-letter",
+  "description": "A Serverless plugin that can configure a lambda with a dead letter queue or topic",
+  "githubUrl": "https://github.com/gmetzker/serverless-plugin-lambda-dead-letter",
+  "status": "active"
+}, {
+  "name": "serverless-plugin-encode-env-var-objects",
+  "description": "Serverless plugin to encode any environment variable objects.",
+  "githubUrl": "https://github.com/yonomi/serverless-plugin-encode-env-var-objects",
+  "status": "active"
+}, {
+  "name": "serverless-dir-config-plugin",
+  "description": "EXPERIMENTAL - Serverless plugin to load function and resource definitions from a directory.",
+  "githubUrl": "https://github.com/economysizegeek/serverless-dir-config-plugin",
+  "status": "active"
+}, {
+  "name": "serverless-cljs-plugin",
+  "description": "Enables Clojurescript as an implementation language for Lambda handlers",
+  "githubUrl": "https://github.com/nervous-systems/serverless-cljs-plugin",
+  "status": "active"
+}, {
+  "name": "serverless-apigateway-log-retention",
+  "description": "Control the retention of your AWS ApiGateway access logs and execution logs.",
+  "githubUrl": "https://github.com/dvla/serverless-apigateway-log-retention",
+  "status": "active"
+}, {
+  "name": "serverless-prune-plugin",
+  "description": "Deletes old versions of functions from AWS, preserving recent and aliased versions",
+  "githubUrl": "https://github.com/claygregory/serverless-prune-plugin",
+  "status": "active"
+}, {
+  "name": "@unly/serverless-env-copy-plugin",
+  "description": "Fetch environment variables and write it to a .env file - Maintained fork from https://github.com/Jimdo/serverless-dotenv",
+  "githubUrl": "https://github.com/UnlyEd/serverless-env-copy-plugin",
+  "status": "active"
+}, {
+  "name": "@unly/serverless-plugin-dynamodb-backups",
+  "description": "Configure automated DynamoDB \"On-Demand\" backups and manage backups lifecycle, powered by AWS Lambda",
+  "githubUrl": "https://github.com/UnlyEd/serverless-plugin-dynamodb-backups",
+  "status": "active"
+}, {
+  "name": "serverless-convention",
+  "description": "Dynamically import resources by defining a convention, split up your yml",
+  "githubUrl": "https://github.com/LeoPlatform/serverless-convention",
+  "status": "active"
+}, {
+  "name": "serverless-openapi-documenter",
+  "description": "A plugin that creates a valid OpenAPI 3.0.X json or yaml schema as well as being able to output a Postman Collection v2 in json.",
+  "githubUrl": "https://github.com/JaredCE/serverless-openapi-documenter",
+  "status": "active"
+}, {
+  "name": "serverless-offline-scheduler",
+  "description": "Runs scheduled functions offline while integrating with serverless-offline",
+  "githubUrl": "https://github.com/ajmath/serverless-offline-scheduler",
+  "status": "active"
+}, {
+  "name": "serverless-aws-alias",
+  "description": "This plugin enables use of AWS aliases on Lambda functions.",
+  "githubUrl": "https://github.com/serverless-heaven/serverless-aws-alias",
+  "status": "active"
+}, {
+  "name": "serverless-plugin-webpack",
+  "description": "A serverless plugin to automatically bundle your functions individually with webpack",
+  "githubUrl": "https://github.com/goldwasserexchange/serverless-plugin-webpack",
+  "status": "active"
+}, {
+  "name": "serverless-secret-baker",
+  "description": "A Serverless Framework Plugin for secure, performant, and deterministic secret management.",
+  "githubUrl": "https://github.com/vacasaoss/serverless-secret-baker",
+  "status": "active"
+}, {
+  "name": "serverless-sqs-fifo",
+  "description": "A serverless plugin to handle creation of sqs fifo queue's in aws (stop-gap)",
+  "githubUrl": "https://github.com/vortarian/serverless-sqs-fifo",
+  "status": "active"
+}, {
+  "name": "serverless-sqs-alarms-plugin",
+  "description": "Wrapper to setup CloudWatch Alarms on SQS queue length",
+  "githubUrl": "https://github.com/sbstjn/serverless-sqs-alarms-plugin",
+  "status": "inactive"
+}, {
+  "name": "serverless-dotenv",
+  "description": "Fetch environment variables and write it to a .env file",
+  "githubUrl": "https://github.com/Jimdo/serverless-dotenv",
+  "status": "active"
+}, {
+  "name": "serverless-haskell",
+  "description": "Deploying Haskell applications to AWS Lambda with Serverless",
+  "githubUrl": "https://github.com/seek-oss/serverless-haskell",
+  "status": "active"
+}, {
+  "name": "serverless-hooks-plugin",
+  "description": "Run arbitrary commands on any lifecycle event in serverless",
+  "githubUrl": "https://github.com/uswitch/serverless-hooks-plugin",
+  "status": "active"
+}, {
+  "name": "serverless-offline-watcher",
+  "description": "Run arbitrary commands when files are changed while running serverless-offline",
+  "githubUrl": "https://github.com/domdomegg/serverless-offline-watcher",
+  "status": "active"
+}, {
+  "name": "serverless-dynalite",
+  "description": "Run dynalite locally (no JVM, all JS) to simulate DynamoDB. Watch serverless.yml for table config updates.",
+  "githubUrl": "https://github.com/sdd/serverless-dynalite",
+  "status": "active"
+}, {
+  "name": "serverless-apig-s3",
+  "description": "Serve static front-end content from S3 via the API Gateway and deploy client bundle to S3.",
+  "githubUrl": "https://github.com/sdd/serverless-apig-s3",
+  "status": "active"
+}, {
+  "name": "serverless-plugin-typescript",
+  "description": "Serverless plugin for zero-config Typescript support.",
+  "githubUrl": "https://github.com/graphcool/serverless-plugin-typescript",
+  "status": "active"
+}, {
+  "name": "serverless-parameters",
+  "description": "Add parameters to the generated cloudformation templates",
+  "githubUrl": "https://github.com/svdgraaf/serverless-parameters",
+  "status": "active"
+}, {
+  "name": "serverless-git-commit-tracker",
+  "description": "Generates a version tracking file for web or API deployment containing the latest git commit version number, deployment stage, and date",
+  "githubUrl": "https://github.com/optimator999/serverless-git-commit-tracker",
+  "status": "active"
+},{
+  "name": "serverless-plugin-epsagon",
+  "description": "Distributed tracing that helps you monitor and troubleshoot your serverless applications.",
+  "githubUrl": "https://github.com/epsagon/serverless-plugin-epsagon",
+  "status": "active"
+}, {
+  "name": "serverless-dynamodb-ttl",
+  "description": "Configure DynamoDB TTL in serverless.yml (until CloudFormation supports this).",
+  "githubUrl": "https://github.com/Jimdo/serverless-dynamodb-ttl",
+  "status": "active"
+}, {
+  "name": "serverless-api-stage",
+  "description": "Serverless API Stage plugin, enables stage variables and logging for AWS API Gateway.",
+  "githubUrl": "https://github.com/leftclickben/serverless-api-stage",
+  "status": "active"
+},{
+  "name": "serverless-plugin-lambda-insights",
+  "description": "A Serverless Framework Plugin allowing to enable Lambda Insights.",
+  "githubUrl": "https://github.com/awslabs/serverless-plugin-lambda-insights",
+  "status": "active"
+},
   {
     "name": "serverless-export-env",
     "description": "Export environment variables into a .env file with automatic AWS CloudFormation reference resolution.",
     "githubUrl": "https://github.com/arabold/serverless-export-env",
     "status": "active"
-  },
-  {
-    "name": "serverless-package-python-functions",
-    "description": "Packaging Python Lambda functions with only the dependencies/requirements they need.",
-    "githubUrl": "https://github.com/ubaniabalogun/serverless-package-python-functions",
-    "status": "active"
-  },
-  {
-    "name": "serverless-plugin-iopipe",
-    "description": "See inside your Lambda functions with high fidelity metrics and monitoring.",
-    "githubUrl": "https://github.com/iopipe/serverless-plugin-iopipe",
-    "status": "active"
-  },
-  {
-    "name": "serverless-plugin-metric",
-    "description": "Creates dynamically AWS metric-filter resources with custom patterns",
-    "githubUrl": "https://github.com/alex20465/serverless-plugin-metric",
-    "status": "active"
-  },
-  {
-    "name": "serverless-sam",
-    "description": "Exports an AWS SAM template for a service created with the Serverless Framework.",
-    "githubUrl": "https://github.com/SAPessi/serverless-sam",
-    "status": "active"
-  },
-  {
-    "name": "serverless-vpc-discovery",
-    "description": "Serverless plugin for discovering VPC / Subnet / Security Group configuration by name.",
-    "githubUrl": "https://github.com/amplify-education/serverless-vpc-discovery",
-    "status": "active"
-  },
-  {
-    "name": "serverless-kubeless",
-    "description": "Serverless plugin for deploying functions to Kubeless.",
-    "githubUrl": "https://github.com/serverless/serverless-kubeless",
-    "status": "active"
-  },
-  {
-    "name": "serverless-kubeless-offline",
-    "description": "Simulates Kubeless NodeJS runtimes to run/call your functions offline using the Serverless Framework.",
-    "githubUrl": "https://github.com/usefulio/serverless-kubeless-offline",
-    "status": "active"
-  },
-  {
-    "name": "serverless-apigwy-binary",
-    "description": "Serverless plugin for configuring API Gateway to return binary responses",
-    "githubUrl": "https://github.com/ryanmurakami/serverless-apigwy-binary",
-    "status": "active"
-  },
-  {
-    "name": "serverless-plugin-browserifier",
-    "description": "Reduce the size and speed up your Node.js based lambda's using browserify.",
-    "githubUrl": "https://github.com/digitalmaas/serverless-plugin-browserifier",
-    "status": "active"
-  },
-  {
-    "name": "@digitalmaas/serverless-plugin-sqs-alarms",
-    "description": "Simplifies the setup of CloudWatch Alarms to monitor the visible messages in an SQS queue.",
-    "githubUrl": "https://github.com/digitalmaas/serverless-plugin-sqs-alarms",
-    "status": "active"
-  },
-  {
-    "name": "serverless-shell",
-    "description": "Drop to a runtime shell with all the environment variables set that you'd have in lambda.",
-    "githubUrl": "https://github.com/UnitedIncome/serverless-shell",
-    "status": "active"
-  },
-  {
-    "name": "serverless-stack-output",
-    "description": "Store output from your AWS CloudFormation Stack in JSON/YAML/TOML files, or to pass it to a JavaScript function for further processing.",
-    "githubUrl": "https://github.com/sbstjn/serverless-stack-output",
-    "status": "active"
-  },
-  {
-    "name": "serverless-gulp",
-    "description": "A thin task wrapper around @goserverless that allows you to automate build, test and deploy tasks using gulp",
-    "githubUrl": "https://github.com/rhythminme/serverless-gulp",
-    "status": "active"
-  },
-  {
-    "name": "serverless-google-cloudfunctions",
-    "description": "This plugin enables support for Google Cloud Functions within the Serverless Framework.",
-    "githubUrl": "https://github.com/serverless/serverless-google-cloudfunctions",
-    "status": "active"
-  },
-  {
-    "name": "serverless-azure-functions",
-    "description": "A Serverless plugin that adds Azure Functions support to the Serverless Framework.",
-    "githubUrl": "https://github.com/serverless/serverless-azure-functions",
-    "status": "active"
-  },
-  {
-    "name": "serverless-sentry",
-    "description": "Automatic monitoring of memory usage, execution timeouts and forwarding of Lambda errors to Sentry (https://sentry.io).",
-    "githubUrl": "https://github.com/arabold/serverless-sentry-plugin",
-    "status": "active"
-  },
-  {
-    "name": "serverless-env-generator",
-    "description": "Manage environment variables with YAML and load them with dotenv. Supports variable encryption with KMS, multiple stages and custom profiles.",
-    "githubUrl": "https://github.com/DieProduktMacher/serverless-env-generator",
-    "status": "active"
-  },
-  {
-    "name": "@redtea/serverless-env-generator",
-    "description": "Manage environment variables with YAML and load them with dotenv. Supports variable encryption with KMS, multiple stages and custom profiles. Maintained fork from https://github.com/DieProduktMacher/serverless-env-generator with more advanced YAML anchors supporting and other.",
-    "githubUrl": "https://github.com/org-redtea/serverless-env-generator",
-    "status": "active"
-  },
-  {
-    "name": "@agiledigital/serverless-sns-sqs-lambda",
-    "description": "Provide the lambda function with the snsSqs event, the plugin will add the AWS SNS topic and subscription, SQS queue and dead letter queue, and the role need for the lambda.",
-    "githubUrl": "https://github.com/agiledigital/serverless-sns-sqs-lambda",
-    "status": "active"
-  },
-  {
-    "name": "serverless-plugin-embedded-env-in-code",
-    "description": "Replace environment variables with static strings before deployment. It’s for Lambda@Edge.",
-    "githubUrl": "https://github.com/zaru/serverless-plugin-embedded-env-in-code",
-    "status": "active"
-  },
-  {
-    "name": "serverless-local-dev-server",
-    "description": "Speeds up development of Alexa Skills, Chatbots and APIs by exposing your functions as local HTTP endpoints and mapping received events.",
-    "githubUrl": "https://github.com/DieProduktMacher/serverless-local-dev-server",
-    "status": "active"
-  },
-  {
-    "name": "serverless-plugin-stack-config",
-    "description": "A serverless plugin to manage configurations for a stack across micro-services.",
-    "githubUrl": "https://github.com/rawphp/serverless-plugin-stack-config",
-    "status": "active"
-  },
-  {
-    "name": "serverless-plugin-elastic-beanstalk",
-    "description": "A serverless plugin to deploy applications to AWS ElasticBeanstalk.",
-    "githubUrl": "https://github.com/rawphp/serverless-plugin-elastic-beanstalk",
-    "status": "active"
-  },
-  {
-    "name": "serverless-s3-local",
-    "description": "A serverless plugin to run a S3 clone on your local machine",
-    "githubUrl": "https://github.com/ar90n/serverless-s3-local",
-    "status": "active"
-  },
-  {
-    "name": "serverless-s3-remover",
-    "description": "A serverless plugin to make s3 buckets empty before deleting cloudformation stack when ```sls remove```",
-    "githubUrl": "https://github.com/sinofseven/serverless-s3-remover",
-    "status": "active"
-  },
-  {
-    "name": "serverless-dynamodb-autoscaling",
-    "description": "Configure Amazon DynamoDB's native Auto Scaling for your table capacities.",
-    "githubUrl": "https://github.com/sbstjn/serverless-dynamodb-autoscaling",
-    "status": "active"
-  },
-  {
-    "name": "serverless-plugin-bespoken",
-    "description": "Creates a local server and a proxy so you don't have to deploy anytime you want to test your code",
-    "githubUrl": "https://github.com/bespoken/serverless-plugin-bespoken",
-    "status": "active"
-  },
-  {
-    "name": "serverless-s3bucket-sync",
-    "description": "Sync a local folder with a S3 bucket after sls deploy",
-    "githubUrl": "https://github.com/sbstjn/serverless-s3bucket-sync",
-    "status": "active"
-  },
-  {
-    "name": "serverless-s3-sync",
-    "description": "A plugin to sync local directories and S3 prefixes for Serverless Framework,",
-    "githubUrl": "https://github.com/k1LoW/serverless-s3-sync",
-    "status": "active"
-  },
-  {
-    "name": "serverless-build-client",
-    "description": "Build your static website with environment variables defined in serverless.yml",
-    "githubUrl": "https://github.com/tgfischer/serverless-build-client",
-    "status": "active"
-  },
-  {
-    "name": "serverless-nested-stack",
-    "description": "A plugin to Workaround for Cloudformation 200 resource limit",
-    "githubUrl": "https://github.com/jagdish-176/serverless-nested-stack",
-    "status": "active"
-  },
-  {
-    "name": "serverless-plugin-common-excludes",
-    "description": "Adds commonly excluded files to package.excludes",
-    "githubUrl": "https://github.com/dougmoscrop/serverless-plugin-common-excludes",
-    "status": "active"
-  },
-  {
-    "name": "serverless-plugin-custom-domain",
-    "description": "Reliably sets a BasePathMapping to an API Gateway Custom Domain",
-    "githubUrl": "https://github.com/dougmoscrop/serverless-plugin-custom-domain",
-    "status": "active"
-  },
-  {
-    "name": "serverless-plugin-split-stacks",
-    "description": "Migrate certain resources to nested stacks",
-    "githubUrl": "https://github.com/dougmoscrop/serverless-plugin-split-stacks",
-    "status": "active"
-  },
-  {
-    "name": "serverless-plugin-log-subscription",
-    "description": "Adds a CloudWatch LogSubscription for functions",
-    "githubUrl": "https://github.com/dougmoscrop/serverless-plugin-log-subscription",
-    "status": "active"
-  },
-  {
-    "name": "serverless-cf-vars",
-    "description": "Enables use of AWS pseudo functions and Fn::Sub string substitution",
-    "githubUrl": "https://gitlab.com/kabo/serverless-cf-vars",
-    "status": "active"
-  },
-  {
-    "name": "serverless-apigateway-plugin",
-    "description": "Configure the AWS api gateway: Binary support, Headers and Body template mappings",
-    "githubUrl": "https://github.com/GFG/serverless-apigateway-plugin",
-    "status": "active"
-  },
-  {
-    "name": "serverless-plugin-deploy-environment",
-    "description": "Plugin to manage deployment environment across stages",
-    "githubUrl": "https://github.com/DopplerLabs/serverless-plugin-deploy-environment",
-    "status": "active"
-  },
-  {
-    "name": "serverless-import-config-plugin",
-    "description": "Import YAML files in serverless.yaml config file",
-    "githubUrl": "https://github.com/KrysKruk/serverless-import-config-plugin",
-    "status": "active"
-  },
-  {
-    "name": "serverless-plugin-aws-resolvers",
-    "description": "Resolves variables from ESS, RDS, or Kinesis for serverless services",
-    "githubUrl": "https://github.com/DopplerLabs/serverless-plugin-aws-resolvers",
-    "status": "active"
-  },
-  {
-    "name": "serverless-plugin-offline-kinesis-events",
-    "description": "Plugin that works with serverless-offline to allow offline testing of serverless functions that are triggered by Kinesis events.",
-    "githubUrl": "https://github.com/DopplerLabs/serverless-plugin-offline-kinesis-events",
-    "status": "active"
-  },
-  {
-    "name": "serverless-micro",
-    "description": "Plugin to help manage multiple micro services under one main service.",
-    "githubUrl": "https://github.com/barstoolsports/serverless-micro",
-    "status": "active"
-  },
-  {
-    "name": "serverless-api-cloudfront",
-    "description": "Plugin that adds CloudFront distribution in front of your API Gateway for custom domain, CDN caching and access log.",
-    "githubUrl": "https://github.com/Droplr/serverless-api-cloudfront",
-    "status": "active"
-  },
-  {
-    "name": "serverless-offline-sns",
-    "description": "Serverless plugin to run a local SNS server and call serverless SNS handlers with events notifications.",
-    "githubUrl": "https://github.com/mj1618/serverless-offline-sns",
-    "status": "active"
-  },
-  {
-    "name": "serverless-stage-manager",
-    "description": "Super simple Serverless plugin for validating stage names before deployment",
-    "githubUrl": "https://github.com/jeremydaly/serverless-stage-manager",
-    "status": "active"
-  },
-  {
-    "name": "serverless-lift",
-    "description": "Deploy high-level components such as static websites, buckets, queues, webhooks...",
-    "githubUrl": "https://github.com/getlift/lift",
-    "status": "active"
-  },
-  {
-    "name": "serverless-spa",
-    "description": "Serverless plugin to deploy your website to AWS S3 using Webpack to bundle it.",
-    "githubUrl": "https://github.com/gilmarsquinelato/serverless-spa",
-    "status": "active"
-  },
-  {
-    "name": "serverless-aws-nested-stacks",
-    "description": "Yet another AWS nested stack plugin!",
-    "githubUrl": "https://github.com/concon121/serverless-plugin-nested-stacks",
-    "status": "active"
-  },
-  {
-    "name": "serverless-aws-resource-names",
-    "description": "Serverless plugin to alter the default naming conventions for sls resources via a simple mapping file.",
-    "githubUrl": "https://github.com/concon121/serverless-plugin-aws-resource-names",
-    "status": "active"
-  },
-  {
-    "name": "serverless-attach-managed-policy",
-    "description": "A Serverless plugin to automatically attach an AWS Managed IAM Policy (or Policies) to all IAM Roles created by the Service.",
-    "githubUrl": "https://github.com/Nordstrom/serverless-attach-managed-policy",
-    "status": "active"
-  },
-  {
-    "name": "serverless-plugin-reducer",
-    "description": "Reduce Node.js lambda package so it contains only lambda dependencies",
-    "githubUrl": "https://github.com/medikoo/serverless-plugin-reducer",
-    "status": "active"
-  },
-  {
-    "name": "serverless-plugin-transpiler",
-    "description": "Transpile lambda files during packaging step",
-    "githubUrl": "https://github.com/medikoo/serverless-plugin-transpiler",
-    "status": "active"
-  },
-  {
-    "name": "serverless-plugin-dynamodb-autoscaling",
-    "description": "Auto generate auto scaling configuration for configured DynamoDB tables",
-    "githubUrl": "https://github.com/medikoo/serverless-plugin-dynamodb-autoscaling",
-    "status": "active"
-  },
-  {
-    "name": "serverless-plugin-vpc-eni-cleanup",
-    "description": "Automatic cleanup of VPC network interfaces on stage removal",
-    "githubUrl": "https://github.com/medikoo/serverless-plugin-vpc-eni-cleanup",
-    "status": "active"
-  },
-  {
-    "name": "serverless-plugin-tracer",
-    "description": "Trace serverless hooks as they execute",
-    "githubUrl": "https://github.com/enykeev/serverless-plugin-tracer",
-    "status": "active"
-  },
-  {
-    "name": "serverless-plugin-stackstorm",
-    "description": "Reusable Functions from StackStorm Exchange",
-    "githubUrl": "https://github.com/StackStorm/serverless-plugin-stackstorm",
-    "status": "active"
-  },
-  {
-    "name": "serverless-iot-local",
-    "description": "AWS Iot events with serverless-offline",
-    "githubUrl": "https://github.com/tradle/serverless-iot-local",
-    "status": "active"
-  },
-  {
-    "name": "serverless-sns-filter",
-    "description": "Serverless plugin to add SNS Subscription Filters to events",
-    "githubUrl": "https://github.com/MechanicalRock/serverless-sns-filter",
-    "status": "active"
-  },
-  {
-    "name": "serverless-apigateway-route-settings",
-    "description": "Configure Route Settings for HTTP API Gateway v2 (Throttling & Detailed Metrics)",
-    "githubUrl": "https://github.com/talbotp/serverless-apigateway-route-settings",
-    "status": "active"
-  },
-  {
-    "name": "serverless-plugin-tagsns",
-    "description": "Serverless plugin to add Tags to SNS Topics",
-    "githubUrl": "https://github.com/ManoManoTech/serverless-plugin-tagsns",
-    "status": "active"
-  },
-  {
-    "name": "serverless-reqvalidator-plugin",
-    "description": "Serverless plugin to add request validator to API Gateway methods",
-    "githubUrl": "https://github.com/RafPe/serverless-reqvalidator-plugin",
-    "status": "active"
-  },
-  {
-    "name": "serverless-plugin-conditional-functions",
-    "description": "A plugin that allows adding simple feature flag per function via a boolean condition.",
-    "githubUrl": "https://github.com/go-dima/serverless-plugin-conditional-functions",
-    "status": "active"
-  },
-  {
-    "name": "serverless-ephemeral",
-    "description": "Build and include custom stateless libraries for any language",
-    "githubUrl": "https://github.com/Accenture/serverless-ephemeral",
-    "status": "active"
-  },
-  {
-    "name": "serverless-content-encoding",
-    "description": "Enable Content Encoding in AWS API Gateway during deployment",
-    "githubUrl": "https://github.com/dong-dohai/serverless-content-encoding",
-    "status": "active"
-  },
-  {
-    "name": "serverless-s3-encryption",
-    "description": "Set or remove the encryption settings on your s3 buckets",
-    "githubUrl": "https://github.com/tradle/serverless-s3-encryption",
-    "status": "active"
-  },
-  {
-    "name": "serverless-plugin-inject-dependencies",
-    "description": "Painlessly deploy serverless projects with only the required dependencies.",
-    "githubUrl": "https://github.com/loanmarket/serverless-plugin-inject-dependencies",
-    "status": "active"
-  },
-  {
-    "name": "serverless-plugin-provider-groups",
-    "description": "A plugin to allow management of grouped settings within large serverless projects.",
-    "githubUrl": "https://github.com/loanmarket/serverless-plugin-provider-groups",
-    "status": "active"
-  },
-  {
-    "name": "serverless-cloudformation-resource-counter",
-    "description": "A plugin to count the resources generated in the AWS CloudFormation stack after deployment.",
-    "githubUrl": "https://github.com/drexler/serverless-cloudformation-resource-counter",
-    "status": "active"
-  },
-  {
-    "name": "serverless-iam-roles-per-function",
-    "description": "Serverless Plugin for easily defining IAM roles per function via the use of iamRoleStatements at the function level.",
-    "githubUrl": "https://github.com/functionalone/serverless-iam-roles-per-function",
-    "status": "active"
-  },
-  {
-    "name": "serverless-frontend-plugin",
-    "description": "Deploy any type of frontend on AWS Cloudfront with Https/SSL termination with your serverless deployments. Integrates with serverless-offline for local development.",
-    "githubUrl": "https://github.com/rogersgt/serverless-frontend-plugin",
-    "status": "active"
-  },
-  {
-    "name": "@fernthedev/serverless-offline-step-functions",
-    "description": "Serverless Offline Plugin to Support Step Functions for Local Development.",
-    "githubUrl": "https://github.com/jefer590/serverless-offline-step-functions",
-    "status": "active"
-  },
-  {
-    "name": "serverless-functions-base-path",
-    "description": "Easily define a base path where your serverless functions are located.",
-    "githubUrl": "https://github.com/kevinrambaud/serverless-functions-base-path",
-    "status": "active"
-  },
-  {
-    "name": "serverless-static",
-    "description": "Easily serve files from a folder while developing on localhost with the serverless-offline plugin",
-    "githubUrl": "https://github.com/iliasbhal/serverless-static",
-    "status": "active"
-  },
-  {
-    "name": "serverless-plugin-static",
-    "description": "Serving static files locally with serverless-offline or a standalone command",
-    "githubUrl": "https://github.com/a-pavlenko/serverless-plugin-static",
-    "status": "active"
-  },
-  {
-    "name": "serverless-plugin-node-shim",
-    "description": "Serverless plugin to run your functions in nodejs version (8 LTS, 9+) on aws lambda",
-    "githubUrl": "https://github.com/jzimmek/serverless-plugin-node-shim",
-    "status": "active"
-  },
-  {
-    "name": "serverless-sagemaker-groundtruth",
-    "description": "Serverless Plugin with AWS Sagemaker Groundtruth utilities (local template testing, e2e tests ...)",
-    "githubUrl": "https://github.com/piercus/serverless-sagemaker-groundtruth",
-    "status": "active"
-  },
-  {
-    "name": "serverless-local-environment",
-    "description": "Serverless plugin to set local environment variables and remote environment variable to different values",
-    "githubUrl": "https://github.com/piercus/serverless-local-environment",
-    "status": "active"
-  },
-  {
-    "name": "serverless-offline-schedule",
-    "description": "Emulate schedule events locally when developing your Serverless project",
-    "githubUrl": "https://github.com/Meemaw/serverless-offline-schedule",
-    "status": "active"
-  },
-  {
-    "name": "serverless-cloudformation-sub-variables",
-    "description": "Serverless framework plugin for easily supporting AWS CloudFormation Sub function variables",
-    "githubUrl": "https://github.com/santiagocardenas/serverless-cloudformation-sub-variables",
-    "status": "active"
-  },
-  {
-    "name": "serverless-sthree-env",
-    "description": "Serverless plugin to get config from a json formatted file in S3 and copy them to environment variable",
-    "githubUrl": "https://github.com/StyleTributeIT/serverless-sthree-env",
-    "status": "active"
-  },
-  {
-    "name": "serverless-plugin-canary-deployments",
-    "description": "A Serverless plugin to implement canary deployments of Lambda functions",
-    "githubUrl": "https://github.com/davidgf/serverless-plugin-canary-deployments",
-    "status": "active"
-  },
-  {
-    "name": "serverless-go-build",
-    "description": "Build go source files (or public functions) using yml definition file",
-    "githubUrl": "https://github.com/sean9keenan/serverless-go-build",
-    "status": "active"
-  },
-  {
-    "name": "bref",
-    "description": "Deploy serverless PHP applications to AWS Lambda",
-    "githubUrl": "https://github.com/brefphp/bref",
-    "status": "active"
-  },
-  {
-    "name": "serverless-local-schedule",
-    "description": "Schedule AWS CloudWatch Event based invocations in local time(with DST support!)",
-    "githubUrl": "https://github.com/UnitedIncome/serverless-local-schedule",
-    "status": "active"
-  },
-  {
-    "name": "go-serverless",
-    "description": "GoFormation for Serverless. Create serverless configs with Go Structs.",
-    "githubUrl": "https://github.com/thepauleh/goserverless",
-    "status": "active"
-  },
-  {
-    "name": "serverless-tag-sqs",
-    "description": "Serverless plugin to tag SQS - Simple Queue Service",
-    "githubUrl": "https://github.com/gfragoso/serverless-tag-sqs",
-    "status": "active"
-  },
-  {
-    "name": "serverless-express",
-    "description": "Making express app development compatible with serverless framework.",
-    "githubUrl": "https://github.com/mikestaub/serverless-express",
-    "status": "active"
-  },
-  {
-    "name": "serverless-aliyun-function-compute",
-    "description": "Serverless Alibaba Cloud Function Compute Plugin",
-    "githubUrl": "https://github.com/aliyun/serverless-aliyun-function-compute",
-    "status": "active"
-  },
-  {
-    "name": "serverless-apib-validator",
-    "description": "Validate that an API Blueprint has full coverage over a Serverless config",
-    "githubUrl": "https://github.com/onlicar/serverless-apib-validator",
-    "status": "active"
-  },
-  {
-    "name": "serverless-package-common",
-    "description": "Deploy microservice Python Serverless services with common code",
-    "githubUrl": "https://github.com/onlicar/serverless-package-common",
-    "status": "active"
-  },
-  {
-    "name": "serverless-tag-api-gateway",
-    "description": "Serverless plugin to tag API Gateway",
-    "githubUrl": "https://github.com/gfragoso/serverless-tag-api-gateway",
-    "status": "active"
-  },
-  {
-    "name": "serverless-tag-cloud-watch-logs",
-    "description": "Serverless plugin to tag CloudWatchLogs",
-    "githubUrl": "https://github.com/gfragoso/serverless-tag-cloud-watch-logs",
-    "status": "active"
-  },
-  {
-    "name": "serverless-create-global-dynamodb-table",
-    "description": "Serverless plugin to create dynamodb global tables",
-    "githubUrl": "https://github.com/rrahul963/serverless-create-global-dynamodb-table",
-    "status": "active"
-  },
-  {
-    "name": "serverless-ding",
-    "description": "Serverless plugin to audibly alert user after deployment",
-    "githubUrl": "https://github.com/sidgonuts/serverless-ding",
-    "status": "active"
-  },
-  {
-    "name": "serverless-ignore",
-    "description": "Serverless plugin to ignore files (.slsignore)",
-    "githubUrl": "https://github.com/nya1/serverless-ignore",
-    "status": "active"
-  },
-  {
-    "name": "serverless-add-api-key",
-    "description": "Serverless plugin to add same api key for multiple serverless services i.e. to re-use apikey across multiple api gateway apis.",
-    "githubUrl": "https://github.com/rrahul963/serverless-add-api-key",
-    "status": "active"
-  },
-  {
-    "name": "serverless-puresec-cli",
-    "description": "Serverless Plugin for magically creating IAM roles that are least privileged per function.",
-    "githubUrl": "https://github.com/puresec/serverless-puresec-cli",
-    "status": "active"
-  },
-  {
-    "name": "serverless-dependson-plugin",
-    "description": "Serverless plugin that automatically generates DependsOn references for AWS Lambdas to prevent AWS RequestLimitExceeded errors.",
-    "githubUrl": "https://github.com/bwinant/serverless-dependson-plugin",
-    "status": "active"
-  },
-  {
-    "name": "serverless-plugin-colocate",
-    "description": "Serverless Plugin to keep your configuration next to your code.",
-    "githubUrl": "https://github.com/aronim/serverless-plugin-colocate",
-    "status": "active"
-  },
-  {
-    "name": "serverless-plugin-fastdeploy",
-    "description": "Serverless Plugin to perform fast deployments for large service packages.",
-    "githubUrl": "https://github.com/aronim/serverless-plugin-fastdeploy",
-    "status": "active"
-  },
-  {
-    "name": "serverless-plugin-parent",
-    "description": "Serverless Plugin that allows you to keep common configuration in a parent serverless.yml",
-    "githubUrl": "https://github.com/aronim/serverless-plugin-parent",
-    "status": "active"
-  },
-  {
-    "name": "serverless-plugin-registry",
-    "description": "Serverless plugin to register function names with AWS SSM Parameter Store.",
-    "githubUrl": "https://github.com/aronim/serverless-plugin-registry",
-    "status": "active"
-  },
-  {
-    "name": "serverless-plugin-offline-dynamodb-stream",
-    "description": "Serverless Plugin for emulating dynamodb stream triggering lambda functions offline",
-    "githubUrl": "https://github.com/orchestrated-io/serverless-plugin-offline-dynamodb-stream",
-    "status": "active"
-  },
-  {
-    "name": "serverless-basic-authentication",
-    "description": "Serverless Plugin for adding Basic Authentication to your api",
-    "githubUrl": "https://github.com/svdgraaf/serverless-basic-authentication",
-    "status": "active"
-  },
-  {
-    "name": "serverless-rust",
-    "description": "Deploy Rustlang applications to AWS Lambda",
-    "githubUrl": "https://github.com/softprops/serverless-rust",
-    "status": "active"
-  },
-  {
-    "name": "sls-rust",
-    "description": "A Serverless plugin to deploy Rust applications",
-    "githubUrl": "https://github.com/fdaciuk/sls-rust",
-    "status": "active"
-  },
-  {
-    "name": "serverless-oncall",
-    "description": "Easily manage oncall for your serverless services",
-    "githubUrl": "https://github.com/softprops/serverless-oncall",
-    "status": "active"
-  },
-  {
-    "name": "serverless-cognito-add-custom-attributes",
-    "description": "Serverless Plugin for adding custom attributes to an existing CloudFormation-managed CognitoUserPool and CognitoUserPoolClient without losing all your users",
-    "githubUrl": "https://github.com/GetWala/serverless-cognito-add-custom-attributes",
-    "status": "active"
-  },
-  {
-    "name": "serverless-plugin-ifelse",
-    "description": "A Serverless Plugin to write If Else conditions in serverless YAML file",
-    "githubUrl": "https://github.com/anantab/serverless-plugin-ifelse",
-    "status": "active"
-  },
-  {
-    "name": "serverless-print-dots",
-    "description": "A Serverless plugin for printing dots in Serverless log during deployment to indicate progress and prevent timeouts in CI/CD platforms.",
-    "githubUrl": "https://github.com/amirklick/serverless-print-dots",
-    "status": "active"
-  },
-  {
-    "name": "serverless-es-logs",
-    "description": "A Serverless plugin to transport logs to ElasticSearch",
-    "githubUrl": "https://github.com/daniel-cottone/serverless-es-logs",
-    "status": "active"
-  },
-  {
-    "name": "serverless-whitelisting",
-    "description": "A Serverless plugin to create a whitelist for IP addresses, CIDR for a serverless application, using resource policies. Support privateStages, publicStages and publicPaths.",
-    "githubUrl": "https://github.com/tho-asterist/serverless-whitelisting",
-    "status": "active"
-  },
-  {
-    "name": "serverless-package-external",
-    "description": "A Serverless plugin to add external folders to the deploy package",
-    "githubUrl": "https://github.com/epsagon/serverless-package-external",
-    "status": "active"
-  },
-  {
-    "name": "serverless-consul-variables",
-    "description": "Retrieve serverless variables from Consul kv",
-    "githubUrl": "https://github.com/zephrax/serverless-consul-variables",
-    "status": "active"
-  },
-  {
-    "name": "serverless-iot-offline",
-    "description": "Serverless plugin that emulates AWS IoT service",
-    "githubUrl": "https://github.com/mitipi/serverless-iot-offline",
-    "status": "active"
-  },
-  {
-    "name": "serverless-ngrok-tunnel",
-    "description": "Serverless plugin that creates ngrok public tunnel on localhost",
-    "githubUrl": "https://github.com/mitipi/serverless-ngrok-tunnel",
-    "status": "active"
-  },
-  {
-    "name": "serverless-oauth-scopes",
-    "description": "A serverless plugin to set OAuth Scopes on APIGateway methods",
-    "githubUrl": "https://github.com/birdcatcher/serverless-oauth-scopes",
-    "status": "active"
-  },
-  {
-    "name": "@haftahave/serverless-ses-template",
-    "description": "A serveless plugin that allows automatically creating, updating and removing AWS SES Templates using a configuration file and keeps your AWS SES Templates synced with your configuration file.",
-    "githubUrl": "https://github.com/haftahave/serverless-ses-template",
-    "status": "active"
-  },
-  {
-    "name": "serverless-api-gateway-caching",
-    "description": "Serverless plugin which configures API Gateway caching",
-    "githubUrl": "https://github.com/DianaIonita/serverless-api-gateway-caching",
-    "status": "active"
-  },
-  {
-    "name": "serverless-api-gateway-throttling",
-    "description": "Serverless plugin which configures throttling for API Gateway endpoints",
-    "githubUrl": "https://github.com/DianaIonita/serverless-api-gateway-throttling",
-    "status": "active"
-  },
-  {
-    "name": "serverless-vpc-plugin",
-    "description": "Serverless plugin to create a VPC",
-    "githubUrl": "https://github.com/smoketurner/serverless-vpc-plugin",
-    "status": "active"
-  },
-  {
-    "name": "serverless-plugin-monorepo",
-    "description": "A serverless plugin that allows use of serverless in a mono repo. Avoids needing to use nohoist by automatic symlinking of all dependencies.",
-    "githubUrl": "https://github.com/Butterwire/serverless-plugin-monorepo",
-    "status": "active"
-  },
-  {
-    "name": "serverless-version-tracker",
-    "description": "A serverless plugin for tracking deployed versions of your code.",
-    "githubUrl": "https://github.com/danepowell/serverless-version-tracker",
-    "status": "active"
-  },
-  {
-    "name": "serverless-confirm-command",
-    "description": "Make commands (and provider-specific options) requiring confirmation before execution.",
-    "githubUrl": "https://github.com/teddy-gustiaux/serverless-confirm-command",
-    "status": "active"
-  },
-  {
-    "name": "serverless-workspaces-plugin",
-    "description": "Resolve and Symlink hoisted dependencies when individually packaging each function",
-    "githubUrl": "https://github.com/sergioramos/serverless-workspaces-plugin",
-    "status": "inactive"
-  },
-  {
-    "name": "serverless-cloudflare-workers",
-    "description": "A serverless plugin allowing you to integrate with [Cloudflare Workers](https://cloudflareworkers.com/#12a9195720fe4ed660949efdbd9c0219:https://tutorial.cloudflareworkers.com)",
-    "githubUrl": "https://github.com/cloudflare/serverless-cloudflare-workers",
-    "status": "active"
-  },
-  {
-    "name": "@endemolshinegroup/serverless-dynamodb-autoscaler",
-    "description": "Autoscale DynamoDB resources with a single AWS AutoScalingPlan",
-    "githubUrl": "https://github.com/EndemolShineGroup/serverless-dynamodb-autoscaler",
-    "status": "active"
-  },
-  {
-    "name": "serverless-plugin-decouple",
-    "description": "Remove ImportValue dependencies by replacing them with the actual values in order to update base exports",
-    "githubUrl": "https://github.com/mutual-of-enumclaw/serverless-plugin-decouple",
-    "status": "active"
-  },
-  {
-    "name": "serverless-docker-artifacts",
-    "description": "Build your artifacts within docker container.",
-    "githubUrl": "https://github.com/Suor/serverless-docker-artifacts",
-    "status": "active"
-  },
-  {
-    "name": "serverless-tesseract",
-    "description": "Add Tesseract OCR Engine to your build.",
-    "githubUrl": "https://github.com/Suor/serverless-tesseract",
-    "status": "active"
-  },
-  {
-    "name": "aws-cognito-idp-userpool-domain",
-    "description": "Manage (add and remove) aws hosted domain on Cognito Userpools",
-    "githubUrl": "https://github.com/rubentrancoso/aws-cognito-idp-userpool-domain",
-    "status": "active"
-  },
-  {
-    "name": "serverless-parcel",
-    "description": "A Serverless plugin to bundle your functions and assets with Parcel Bundler",
-    "githubUrl": "https://github.com/johnagan/serverless-parcel",
-    "status": "active"
-  },
-  {
-    "name": "serverless-vault-plugin",
-    "description": "A Serverless plugin to retrieve passwords from vault and encrypt to kms",
-    "githubUrl": "https://github.com/Rondineli/serverless-vault-plugin",
-    "status": "active"
-  },
-  {
-    "name": "serverless-function-outputs",
-    "description": "Adds function Name and ARN outputs without version suffix",
-    "githubUrl": "https://github.com/RogerBarreto/serverless-function-outputs",
-    "status": "active"
-  },
-  {
-    "name": "serverless-website-domain",
-    "description": "A plugin that creates Route 53 records that point to your Cloudfront hosted static website, including www/non-www redirects.",
-    "githubUrl": "https://github.com/williamsandonz/serverless-website-domain",
-    "status": "active"
-  },
+  }, {
+  "name": "serverless-package-python-functions",
+  "description": "Packaging Python Lambda functions with only the dependencies/requirements they need.",
+  "githubUrl": "https://github.com/ubaniabalogun/serverless-package-python-functions",
+  "status": "active"
+}, {
+  "name": "serverless-plugin-iopipe",
+  "description": "See inside your Lambda functions with high fidelity metrics and monitoring.",
+  "githubUrl": "https://github.com/iopipe/serverless-plugin-iopipe",
+  "status": "active"
+}, {
+  "name": "serverless-plugin-metric",
+  "description": "Creates dynamically AWS metric-filter resources with custom patterns",
+  "githubUrl": "https://github.com/alex20465/serverless-plugin-metric",
+  "status": "active"
+}, {
+  "name": "serverless-sam",
+  "description": "Exports an AWS SAM template for a service created with the Serverless Framework.",
+  "githubUrl": "https://github.com/SAPessi/serverless-sam",
+  "status": "active"
+}, {
+  "name": "serverless-vpc-discovery",
+  "description": "Serverless plugin for discovering VPC / Subnet / Security Group configuration by name.",
+  "githubUrl": "https://github.com/amplify-education/serverless-vpc-discovery",
+  "status": "active"
+}, {
+  "name": "serverless-kubeless",
+  "description": "Serverless plugin for deploying functions to Kubeless.",
+  "githubUrl": "https://github.com/serverless/serverless-kubeless",
+  "status": "active"
+}, {
+  "name": "serverless-kubeless-offline",
+  "description": "Simulates Kubeless NodeJS runtimes to run/call your functions offline using the Serverless Framework.",
+  "githubUrl": "https://github.com/usefulio/serverless-kubeless-offline",
+  "status": "active"
+}, {
+  "name": "serverless-apigwy-binary",
+  "description": "Serverless plugin for configuring API Gateway to return binary responses",
+  "githubUrl": "https://github.com/ryanmurakami/serverless-apigwy-binary",
+  "status": "active"
+}, {
+  "name": "serverless-plugin-browserifier",
+  "description": "Reduce the size and speed up your Node.js based lambda's using browserify.",
+  "githubUrl": "https://github.com/digitalmaas/serverless-plugin-browserifier",
+  "status": "active"
+}, {
+  "name": "@digitalmaas/serverless-plugin-sqs-alarms",
+  "description": "Simplifies the setup of CloudWatch Alarms to monitor the visible messages in an SQS queue.",
+  "githubUrl": "https://github.com/digitalmaas/serverless-plugin-sqs-alarms",
+  "status": "active"
+}, {
+  "name": "serverless-shell",
+  "description": "Drop to a runtime shell with all the environment variables set that you'd have in lambda.",
+  "githubUrl": "https://github.com/UnitedIncome/serverless-shell",
+  "status": "active"
+}, {
+  "name": "serverless-stack-output",
+  "description": "Store output from your AWS CloudFormation Stack in JSON/YAML/TOML files, or to pass it to a JavaScript function for further processing.",
+  "githubUrl": "https://github.com/sbstjn/serverless-stack-output",
+  "status": "active"
+}, {
+  "name": "serverless-gulp",
+  "description": "A thin task wrapper around @goserverless that allows you to automate build, test and deploy tasks using gulp",
+  "githubUrl": "https://github.com/rhythminme/serverless-gulp",
+  "status": "active"
+}, {
+  "name": "serverless-google-cloudfunctions",
+  "description": "This plugin enables support for Google Cloud Functions within the Serverless Framework.",
+  "githubUrl": "https://github.com/serverless/serverless-google-cloudfunctions",
+  "status": "active"
+}, {
+  "name": "serverless-azure-functions",
+  "description": "A Serverless plugin that adds Azure Functions support to the Serverless Framework.",
+  "githubUrl": "https://github.com/serverless/serverless-azure-functions",
+  "status": "active"
+}, {
+  "name": "serverless-sentry",
+  "description": "Automatic monitoring of memory usage, execution timeouts and forwarding of Lambda errors to Sentry (https://sentry.io).",
+  "githubUrl": "https://github.com/arabold/serverless-sentry-plugin",
+  "status": "active"
+}, {
+  "name": "serverless-env-generator",
+  "description": "Manage environment variables with YAML and load them with dotenv. Supports variable encryption with KMS, multiple stages and custom profiles.",
+  "githubUrl": "https://github.com/DieProduktMacher/serverless-env-generator",
+  "status": "active"
+}, {
+  "name": "@redtea/serverless-env-generator",
+  "description": "Manage environment variables with YAML and load them with dotenv. Supports variable encryption with KMS, multiple stages and custom profiles. Maintained fork from https://github.com/DieProduktMacher/serverless-env-generator with more advanced YAML anchors supporting and other.",
+  "githubUrl": "https://github.com/org-redtea/serverless-env-generator",
+  "status": "active"
+}, {
+  "name": "@agiledigital/serverless-sns-sqs-lambda",
+  "description": "Provide the lambda function with the snsSqs event, the plugin will add the AWS SNS topic and subscription, SQS queue and dead letter queue, and the role need for the lambda.",
+  "githubUrl": "https://github.com/agiledigital/serverless-sns-sqs-lambda",
+  "status": "active"
+}, {
+  "name": "serverless-plugin-embedded-env-in-code",
+  "description": "Replace environment variables with static strings before deployment. It’s for Lambda@Edge.",
+  "githubUrl": "https://github.com/zaru/serverless-plugin-embedded-env-in-code",
+  "status": "active"
+}, {
+  "name": "serverless-local-dev-server",
+  "description": "Speeds up development of Alexa Skills, Chatbots and APIs by exposing your functions as local HTTP endpoints and mapping received events.",
+  "githubUrl": "https://github.com/DieProduktMacher/serverless-local-dev-server",
+  "status": "active"
+}, {
+  "name": "serverless-plugin-stack-config",
+  "description": "A serverless plugin to manage configurations for a stack across micro-services.",
+  "githubUrl": "https://github.com/rawphp/serverless-plugin-stack-config",
+  "status": "active"
+}, {
+  "name": "serverless-plugin-elastic-beanstalk",
+  "description": "A serverless plugin to deploy applications to AWS ElasticBeanstalk.",
+  "githubUrl": "https://github.com/rawphp/serverless-plugin-elastic-beanstalk",
+  "status": "active"
+}, {
+  "name": "serverless-s3-local",
+  "description": "A serverless plugin to run a S3 clone on your local machine",
+  "githubUrl": "https://github.com/ar90n/serverless-s3-local",
+  "status": "active"
+}, {
+  "name": "serverless-s3-remover",
+  "description": "A serverless plugin to make s3 buckets empty before deleting cloudformation stack when ```sls remove```",
+  "githubUrl": "https://github.com/sinofseven/serverless-s3-remover",
+  "status": "active"
+}, {
+  "name": "serverless-dynamodb-autoscaling",
+  "description": "Configure Amazon DynamoDB's native Auto Scaling for your table capacities.",
+  "githubUrl": "https://github.com/sbstjn/serverless-dynamodb-autoscaling",
+  "status": "active"
+}, {
+  "name": "serverless-plugin-bespoken",
+  "description": "Creates a local server and a proxy so you don't have to deploy anytime you want to test your code",
+  "githubUrl": "https://github.com/bespoken/serverless-plugin-bespoken",
+  "status": "active"
+}, {
+  "name": "serverless-s3bucket-sync",
+  "description": "Sync a local folder with a S3 bucket after sls deploy",
+  "githubUrl": "https://github.com/sbstjn/serverless-s3bucket-sync",
+  "status": "active"
+}, {
+  "name": "serverless-s3-sync",
+  "description": "A plugin to sync local directories and S3 prefixes for Serverless Framework,",
+  "githubUrl": "https://github.com/k1LoW/serverless-s3-sync",
+  "status": "active"
+}, {
+  "name": "serverless-build-client",
+  "description": "Build your static website with environment variables defined in serverless.yml",
+  "githubUrl": "https://github.com/tgfischer/serverless-build-client",
+  "status": "active"
+}, {
+  "name": "serverless-nested-stack",
+  "description": "A plugin to Workaround for Cloudformation 200 resource limit",
+  "githubUrl": "https://github.com/jagdish-176/serverless-nested-stack",
+  "status": "active"
+}, {
+  "name": "serverless-plugin-common-excludes",
+  "description": "Adds commonly excluded files to package.excludes",
+  "githubUrl": "https://github.com/dougmoscrop/serverless-plugin-common-excludes",
+  "status": "active"
+}, {
+  "name": "serverless-plugin-custom-domain",
+  "description": "Reliably sets a BasePathMapping to an API Gateway Custom Domain",
+  "githubUrl": "https://github.com/dougmoscrop/serverless-plugin-custom-domain",
+  "status": "active"
+}, {
+  "name": "serverless-plugin-split-stacks",
+  "description": "Migrate certain resources to nested stacks",
+  "githubUrl": "https://github.com/dougmoscrop/serverless-plugin-split-stacks",
+  "status": "active"
+}, {
+  "name": "serverless-plugin-log-subscription",
+  "description": "Adds a CloudWatch LogSubscription for functions",
+  "githubUrl": "https://github.com/dougmoscrop/serverless-plugin-log-subscription",
+  "status": "active"
+}, {
+  "name": "serverless-cf-vars",
+  "description": "Enables use of AWS pseudo functions and Fn::Sub string substitution",
+  "githubUrl": "https://gitlab.com/kabo/serverless-cf-vars",
+  "status": "active"
+}, {
+  "name": "serverless-apigateway-plugin",
+  "description": "Configure the AWS api gateway: Binary support, Headers and Body template mappings",
+  "githubUrl": "https://github.com/GFG/serverless-apigateway-plugin",
+  "status": "active"
+}, {
+  "name": "serverless-plugin-deploy-environment",
+  "description": "Plugin to manage deployment environment across stages",
+  "githubUrl": "https://github.com/DopplerLabs/serverless-plugin-deploy-environment",
+  "status": "active"
+}, {
+  "name": "serverless-import-config-plugin",
+  "description": "Import YAML files in serverless.yaml config file",
+  "githubUrl": "https://github.com/KrysKruk/serverless-import-config-plugin",
+  "status": "active"
+}, {
+  "name": "serverless-plugin-aws-resolvers",
+  "description": "Resolves variables from ESS, RDS, or Kinesis for serverless services",
+  "githubUrl": "https://github.com/DopplerLabs/serverless-plugin-aws-resolvers",
+  "status": "active"
+}, {
+  "name": "serverless-plugin-offline-kinesis-events",
+  "description": "Plugin that works with serverless-offline to allow offline testing of serverless functions that are triggered by Kinesis events.",
+  "githubUrl": "https://github.com/DopplerLabs/serverless-plugin-offline-kinesis-events",
+  "status": "active"
+}, {
+  "name": "serverless-micro",
+  "description": "Plugin to help manage multiple micro services under one main service.",
+  "githubUrl": "https://github.com/barstoolsports/serverless-micro",
+  "status": "active"
+}, {
+  "name": "serverless-api-cloudfront",
+  "description": "Plugin that adds CloudFront distribution in front of your API Gateway for custom domain, CDN caching and access log.",
+  "githubUrl": "https://github.com/Droplr/serverless-api-cloudfront",
+  "status": "active"
+}, {
+  "name": "serverless-offline-sns",
+  "description": "Serverless plugin to run a local SNS server and call serverless SNS handlers with events notifications.",
+  "githubUrl": "https://github.com/mj1618/serverless-offline-sns",
+  "status": "active"
+}, {
+  "name": "serverless-stage-manager",
+  "description": "Super simple Serverless plugin for validating stage names before deployment",
+  "githubUrl": "https://github.com/jeremydaly/serverless-stage-manager",
+  "status": "active"
+}, {
+  "name": "serverless-lift",
+  "description": "Deploy high-level components such as static websites, buckets, queues, webhooks...",
+  "githubUrl": "https://github.com/getlift/lift",
+  "status": "active"
+}, {
+  "name": "serverless-spa",
+  "description": "Serverless plugin to deploy your website to AWS S3 using Webpack to bundle it.",
+  "githubUrl": "https://github.com/gilmarsquinelato/serverless-spa",
+  "status": "active"
+}, {
+  "name": "serverless-aws-nested-stacks",
+  "description": "Yet another AWS nested stack plugin!",
+  "githubUrl": "https://github.com/concon121/serverless-plugin-nested-stacks",
+  "status": "active"
+}, {
+  "name": "serverless-aws-resource-names",
+  "description": "Serverless plugin to alter the default naming conventions for sls resources via a simple mapping file.",
+  "githubUrl": "https://github.com/concon121/serverless-plugin-aws-resource-names",
+  "status": "active"
+}, {
+  "name": "serverless-attach-managed-policy",
+  "description": "A Serverless plugin to automatically attach an AWS Managed IAM Policy (or Policies) to all IAM Roles created by the Service.",
+  "githubUrl": "https://github.com/Nordstrom/serverless-attach-managed-policy",
+  "status": "active"
+}, {
+  "name": "serverless-plugin-reducer",
+  "description": "Reduce Node.js lambda package so it contains only lambda dependencies",
+  "githubUrl": "https://github.com/medikoo/serverless-plugin-reducer",
+  "status": "active"
+}, {
+  "name": "serverless-plugin-transpiler",
+  "description": "Transpile lambda files during packaging step",
+  "githubUrl": "https://github.com/medikoo/serverless-plugin-transpiler",
+  "status": "active"
+}, {
+  "name": "serverless-plugin-dynamodb-autoscaling",
+  "description": "Auto generate auto scaling configuration for configured DynamoDB tables",
+  "githubUrl": "https://github.com/medikoo/serverless-plugin-dynamodb-autoscaling",
+  "status": "active"
+}, {
+  "name": "serverless-plugin-vpc-eni-cleanup",
+  "description": "Automatic cleanup of VPC network interfaces on stage removal",
+  "githubUrl": "https://github.com/medikoo/serverless-plugin-vpc-eni-cleanup",
+  "status": "active"
+}, {
+  "name": "serverless-plugin-tracer",
+  "description": "Trace serverless hooks as they execute",
+  "githubUrl": "https://github.com/enykeev/serverless-plugin-tracer",
+  "status": "active"
+}, {
+  "name": "serverless-plugin-stackstorm",
+  "description": "Reusable Functions from StackStorm Exchange",
+  "githubUrl": "https://github.com/StackStorm/serverless-plugin-stackstorm",
+  "status": "active"
+}, {
+  "name": "serverless-iot-local",
+  "description": "AWS Iot events with serverless-offline",
+  "githubUrl": "https://github.com/tradle/serverless-iot-local",
+  "status": "active"
+}, {
+  "name": "serverless-sns-filter",
+  "description": "Serverless plugin to add SNS Subscription Filters to events",
+  "githubUrl": "https://github.com/MechanicalRock/serverless-sns-filter",
+  "status": "active"
+}, {
+  "name": "serverless-apigateway-route-settings",
+  "description": "Configure Route Settings for HTTP API Gateway v2 (Throttling & Detailed Metrics)",
+  "githubUrl": "https://github.com/talbotp/serverless-apigateway-route-settings",
+  "status": "active"
+}, {
+  "name": "serverless-plugin-tagsns",
+  "description": "Serverless plugin to add Tags to SNS Topics",
+  "githubUrl": "https://github.com/ManoManoTech/serverless-plugin-tagsns",
+  "status": "active"
+}, {
+  "name": "serverless-reqvalidator-plugin",
+  "description": "Serverless plugin to add request validator to API Gateway methods",
+  "githubUrl": "https://github.com/RafPe/serverless-reqvalidator-plugin",
+  "status": "active"
+}, {
+  "name": "serverless-plugin-conditional-functions",
+  "description": "A plugin that allows adding simple feature flag per function via a boolean condition.",
+  "githubUrl": "https://github.com/go-dima/serverless-plugin-conditional-functions",
+  "status": "active"
+}, {
+  "name": "serverless-ephemeral",
+  "description": "Build and include custom stateless libraries for any language",
+  "githubUrl": "https://github.com/Accenture/serverless-ephemeral",
+  "status": "active"
+}, {
+  "name": "serverless-content-encoding",
+  "description": "Enable Content Encoding in AWS API Gateway during deployment",
+  "githubUrl": "https://github.com/dong-dohai/serverless-content-encoding",
+  "status": "active"
+}, {
+  "name": "serverless-s3-encryption",
+  "description": "Set or remove the encryption settings on your s3 buckets",
+  "githubUrl": "https://github.com/tradle/serverless-s3-encryption",
+  "status": "active"
+}, {
+  "name": "serverless-plugin-inject-dependencies",
+  "description": "Painlessly deploy serverless projects with only the required dependencies.",
+  "githubUrl": "https://github.com/loanmarket/serverless-plugin-inject-dependencies",
+  "status": "active"
+}, {
+  "name": "serverless-plugin-provider-groups",
+  "description": "A plugin to allow management of grouped settings within large serverless projects.",
+  "githubUrl": "https://github.com/loanmarket/serverless-plugin-provider-groups",
+  "status": "active"
+}, {
+  "name": "serverless-cloudformation-resource-counter",
+  "description": "A plugin to count the resources generated in the AWS CloudFormation stack after deployment.",
+  "githubUrl": "https://github.com/drexler/serverless-cloudformation-resource-counter",
+  "status": "active"
+}, {
+  "name": "serverless-iam-roles-per-function",
+  "description": "Serverless Plugin for easily defining IAM roles per function via the use of iamRoleStatements at the function level.",
+  "githubUrl": "https://github.com/functionalone/serverless-iam-roles-per-function",
+  "status": "active"
+}, {
+  "name": "serverless-frontend-plugin",
+  "description": "Deploy any type of frontend on AWS Cloudfront with Https/SSL termination with your serverless deployments. Integrates with serverless-offline for local development.",
+  "githubUrl": "https://github.com/rogersgt/serverless-frontend-plugin",
+  "status": "active"
+}, {
+  "name": "@fernthedev/serverless-offline-step-functions",
+  "description": "Serverless Offline Plugin to Support Step Functions for Local Development.",
+  "githubUrl": "https://github.com/jefer590/serverless-offline-step-functions",
+  "status": "active"
+},  {
+  "name": "serverless-functions-base-path",
+  "description": "Easily define a base path where your serverless functions are located.",
+  "githubUrl": "https://github.com/kevinrambaud/serverless-functions-base-path",
+  "status": "active"
+}, {
+  "name": "serverless-static",
+  "description": "Easily serve files from a folder while developing on localhost with the serverless-offline plugin",
+  "githubUrl": "https://github.com/iliasbhal/serverless-static",
+  "status": "active"
+}, {
+  "name": "serverless-plugin-static",
+  "description": "Serving static files locally with serverless-offline or a standalone command",
+  "githubUrl": "https://github.com/a-pavlenko/serverless-plugin-static",
+  "status": "active"
+}, {
+  "name": "serverless-plugin-node-shim",
+  "description": "Serverless plugin to run your functions in nodejs version (8 LTS, 9+) on aws lambda",
+  "githubUrl": "https://github.com/jzimmek/serverless-plugin-node-shim",
+  "status": "active"
+}, {
+  "name": "serverless-sagemaker-groundtruth",
+  "description": "Serverless Plugin with AWS Sagemaker Groundtruth utilities (local template testing, e2e tests ...)",
+  "githubUrl": "https://github.com/piercus/serverless-sagemaker-groundtruth",
+  "status": "active"
+}, {
+  "name": "serverless-local-environment",
+  "description": "Serverless plugin to set local environment variables and remote environment variable to different values",
+  "githubUrl": "https://github.com/piercus/serverless-local-environment",
+  "status": "active"
+}, {
+  "name": "serverless-offline-schedule",
+  "description": "Emulate schedule events locally when developing your Serverless project",
+  "githubUrl": "https://github.com/Meemaw/serverless-offline-schedule",
+  "status": "active"
+}, {
+  "name": "serverless-cloudformation-sub-variables",
+  "description": "Serverless framework plugin for easily supporting AWS CloudFormation Sub function variables",
+  "githubUrl": "https://github.com/santiagocardenas/serverless-cloudformation-sub-variables",
+  "status": "active"
+}, {
+  "name": "serverless-sthree-env",
+  "description": "Serverless plugin to get config from a json formatted file in S3 and copy them to environment variable",
+  "githubUrl": "https://github.com/StyleTributeIT/serverless-sthree-env",
+  "status": "active"
+}, {
+  "name": "serverless-plugin-canary-deployments",
+  "description": "A Serverless plugin to implement canary deployments of Lambda functions",
+  "githubUrl": "https://github.com/davidgf/serverless-plugin-canary-deployments",
+  "status": "active"
+}, {
+  "name": "serverless-go-build",
+  "description": "Build go source files (or public functions) using yml definition file",
+  "githubUrl": "https://github.com/sean9keenan/serverless-go-build",
+  "status": "active"
+}, {
+  "name": "bref",
+  "description": "Deploy serverless PHP applications to AWS Lambda",
+  "githubUrl": "https://github.com/brefphp/bref",
+  "status": "active"
+}, {
+  "name": "serverless-local-schedule",
+  "description": "Schedule AWS CloudWatch Event based invocations in local time(with DST support!)",
+  "githubUrl": "https://github.com/UnitedIncome/serverless-local-schedule",
+  "status": "active"
+}, {
+  "name": "go-serverless",
+  "description": "GoFormation for Serverless. Create serverless configs with Go Structs.",
+  "githubUrl": "https://github.com/thepauleh/goserverless",
+  "status": "active"
+}, {
+  "name": "serverless-tag-sqs",
+  "description": "Serverless plugin to tag SQS - Simple Queue Service",
+  "githubUrl": "https://github.com/gfragoso/serverless-tag-sqs",
+  "status": "active"
+}, {
+  "name": "serverless-express",
+  "description": "Making express app development compatible with serverless framework.",
+  "githubUrl": "https://github.com/mikestaub/serverless-express",
+  "status": "active"
+}, {
+  "name": "serverless-aliyun-function-compute",
+  "description": "Serverless Alibaba Cloud Function Compute Plugin",
+  "githubUrl": "https://github.com/aliyun/serverless-aliyun-function-compute",
+  "status": "active"
+}, {
+  "name": "serverless-apib-validator",
+  "description": "Validate that an API Blueprint has full coverage over a Serverless config",
+  "githubUrl": "https://github.com/onlicar/serverless-apib-validator",
+  "status": "active"
+}, {
+  "name": "serverless-package-common",
+  "description": "Deploy microservice Python Serverless services with common code",
+  "githubUrl": "https://github.com/onlicar/serverless-package-common",
+  "status": "active"
+}, {
+  "name": "serverless-tag-api-gateway",
+  "description": "Serverless plugin to tag API Gateway",
+  "githubUrl": "https://github.com/gfragoso/serverless-tag-api-gateway",
+  "status": "active"
+}, {
+  "name": "serverless-tag-cloud-watch-logs",
+  "description": "Serverless plugin to tag CloudWatchLogs",
+  "githubUrl": "https://github.com/gfragoso/serverless-tag-cloud-watch-logs",
+  "status": "active"
+}, {
+  "name": "serverless-create-global-dynamodb-table",
+  "description": "Serverless plugin to create dynamodb global tables",
+  "githubUrl": "https://github.com/rrahul963/serverless-create-global-dynamodb-table",
+  "status": "active"
+}, {
+  "name": "serverless-ding",
+  "description": "Serverless plugin to audibly alert user after deployment",
+  "githubUrl": "https://github.com/sidgonuts/serverless-ding",
+  "status": "active"
+}, {
+  "name": "serverless-ignore",
+  "description": "Serverless plugin to ignore files (.slsignore)",
+  "githubUrl": "https://github.com/nya1/serverless-ignore",
+  "status": "active"
+}, {
+  "name": "serverless-add-api-key",
+  "description": "Serverless plugin to add same api key for multiple serverless services i.e. to re-use apikey across multiple api gateway apis.",
+  "githubUrl": "https://github.com/rrahul963/serverless-add-api-key",
+  "status": "active"
+}, {
+  "name": "serverless-puresec-cli",
+  "description": "Serverless Plugin for magically creating IAM roles that are least privileged per function.",
+  "githubUrl": "https://github.com/puresec/serverless-puresec-cli",
+  "status": "active"
+}, {
+  "name": "serverless-dependson-plugin",
+  "description": "Serverless plugin that automatically generates DependsOn references for AWS Lambdas to prevent AWS RequestLimitExceeded errors.",
+  "githubUrl": "https://github.com/bwinant/serverless-dependson-plugin",
+  "status": "active"
+}, {
+  "name": "serverless-plugin-colocate",
+  "description": "Serverless Plugin to keep your configuration next to your code.",
+  "githubUrl": "https://github.com/aronim/serverless-plugin-colocate",
+  "status": "active"
+}, {
+  "name": "serverless-plugin-fastdeploy",
+  "description": "Serverless Plugin to perform fast deployments for large service packages.",
+  "githubUrl": "https://github.com/aronim/serverless-plugin-fastdeploy",
+  "status": "active"
+}, {
+  "name": "serverless-plugin-parent",
+  "description": "Serverless Plugin that allows you to keep common configuration in a parent serverless.yml",
+  "githubUrl": "https://github.com/aronim/serverless-plugin-parent",
+  "status": "active"
+}, {
+  "name": "serverless-plugin-registry",
+  "description": "Serverless plugin to register function names with AWS SSM Parameter Store.",
+  "githubUrl": "https://github.com/aronim/serverless-plugin-registry",
+  "status": "active"
+}, {
+  "name": "serverless-plugin-offline-dynamodb-stream",
+  "description": "Serverless Plugin for emulating dynamodb stream triggering lambda functions offline",
+  "githubUrl": "https://github.com/orchestrated-io/serverless-plugin-offline-dynamodb-stream",
+  "status": "active"
+}, {
+  "name": "serverless-basic-authentication",
+  "description": "Serverless Plugin for adding Basic Authentication to your api",
+  "githubUrl": "https://github.com/svdgraaf/serverless-basic-authentication",
+  "status": "active"
+}, {
+  "name": "serverless-rust",
+  "description": "Deploy Rustlang applications to AWS Lambda",
+  "githubUrl": "https://github.com/softprops/serverless-rust",
+  "status": "active"
+}, {
+  "name": "sls-rust",
+  "description": "A Serverless plugin to deploy Rust applications",
+  "githubUrl": "https://github.com/fdaciuk/sls-rust",
+  "status": "active"
+},{
+  "name": "serverless-oncall",
+  "description": "Easily manage oncall for your serverless services",
+  "githubUrl": "https://github.com/softprops/serverless-oncall",
+  "status": "active"
+}, {
+  "name": "serverless-cognito-add-custom-attributes",
+  "description": "Serverless Plugin for adding custom attributes to an existing CloudFormation-managed CognitoUserPool and CognitoUserPoolClient without losing all your users",
+  "githubUrl": "https://github.com/GetWala/serverless-cognito-add-custom-attributes",
+  "status": "active"
+}, {
+  "name": "serverless-plugin-ifelse",
+  "description": "A Serverless Plugin to write If Else conditions in serverless YAML file",
+  "githubUrl": "https://github.com/anantab/serverless-plugin-ifelse",
+  "status": "active"
+}, {
+  "name": "serverless-print-dots",
+  "description": "A Serverless plugin for printing dots in Serverless log during deployment to indicate progress and prevent timeouts in CI/CD platforms.",
+  "githubUrl": "https://github.com/amirklick/serverless-print-dots",
+  "status": "active"
+}, {
+  "name": "serverless-es-logs",
+  "description": "A Serverless plugin to transport logs to ElasticSearch",
+  "githubUrl": "https://github.com/daniel-cottone/serverless-es-logs",
+  "status": "active"
+}, {
+  "name": "serverless-whitelisting",
+  "description": "A Serverless plugin to create a whitelist for IP addresses, CIDR for a serverless application, using resource policies. Support privateStages, publicStages and publicPaths.",
+  "githubUrl": "https://github.com/tho-asterist/serverless-whitelisting",
+  "status": "active"
+}, {
+  "name": "serverless-package-external",
+  "description": "A Serverless plugin to add external folders to the deploy package",
+  "githubUrl": "https://github.com/epsagon/serverless-package-external",
+  "status": "active"
+}, {
+  "name": "serverless-consul-variables",
+  "description": "Retrieve serverless variables from Consul kv",
+  "githubUrl": "https://github.com/zephrax/serverless-consul-variables",
+  "status": "active"
+}, {
+  "name": "serverless-iot-offline",
+  "description": "Serverless plugin that emulates AWS IoT service",
+  "githubUrl": "https://github.com/mitipi/serverless-iot-offline",
+  "status": "active"
+}, {
+  "name": "serverless-ngrok-tunnel",
+  "description": "Serverless plugin that creates ngrok public tunnel on localhost",
+  "githubUrl": "https://github.com/mitipi/serverless-ngrok-tunnel",
+  "status": "active"
+}, {
+  "name": "serverless-oauth-scopes",
+  "description": "A serverless plugin to set OAuth Scopes on APIGateway methods",
+  "githubUrl": "https://github.com/birdcatcher/serverless-oauth-scopes",
+  "status": "active"
+}, {
+  "name": "@haftahave/serverless-ses-template",
+  "description": "A serveless plugin that allows automatically creating, updating and removing AWS SES Templates using a configuration file and keeps your AWS SES Templates synced with your configuration file.",
+  "githubUrl": "https://github.com/haftahave/serverless-ses-template",
+  "status": "active"
+}, {
+  "name": "serverless-api-gateway-caching",
+  "description": "Serverless plugin which configures API Gateway caching",
+  "githubUrl": "https://github.com/DianaIonita/serverless-api-gateway-caching",
+  "status": "active"
+}, {
+  "name": "serverless-api-gateway-throttling",
+  "description": "Serverless plugin which configures throttling for API Gateway endpoints",
+  "githubUrl": "https://github.com/DianaIonita/serverless-api-gateway-throttling",
+  "status": "active"
+}, {
+  "name": "serverless-vpc-plugin",
+  "description": "Serverless plugin to create a VPC",
+  "githubUrl": "https://github.com/smoketurner/serverless-vpc-plugin",
+  "status": "active"
+}, {
+  "name": "serverless-plugin-monorepo",
+  "description": "A serverless plugin that allows use of serverless in a mono repo. Avoids needing to use nohoist by automatic symlinking of all dependencies.",
+  "githubUrl": "https://github.com/Butterwire/serverless-plugin-monorepo",
+  "status": "active"
+}, {
+  "name": "serverless-version-tracker",
+  "description": "A serverless plugin for tracking deployed versions of your code.",
+  "githubUrl": "https://github.com/danepowell/serverless-version-tracker",
+  "status": "active"
+}, {
+  "name": "serverless-confirm-command",
+  "description": "Make commands (and provider-specific options) requiring confirmation before execution.",
+  "githubUrl": "https://github.com/teddy-gustiaux/serverless-confirm-command",
+  "status": "active"
+}, {
+  "name": "serverless-workspaces-plugin",
+  "description": "Resolve and Symlink hoisted dependencies when individually packaging each function",
+  "githubUrl": "https://github.com/sergioramos/serverless-workspaces-plugin",
+  "status": "inactive"
+}, {
+  "name": "serverless-cloudflare-workers",
+  "description": "A serverless plugin allowing you to integrate with [Cloudflare Workers](https://cloudflareworkers.com/#12a9195720fe4ed660949efdbd9c0219:https://tutorial.cloudflareworkers.com)",
+  "githubUrl": "https://github.com/cloudflare/serverless-cloudflare-workers",
+  "status": "active"
+}, {
+  "name": "@endemolshinegroup/serverless-dynamodb-autoscaler",
+  "description": "Autoscale DynamoDB resources with a single AWS AutoScalingPlan",
+  "githubUrl": "https://github.com/EndemolShineGroup/serverless-dynamodb-autoscaler",
+  "status": "active"
+}, {
+  "name": "serverless-plugin-decouple",
+  "description": "Remove ImportValue dependencies by replacing them with the actual values in order to update base exports",
+  "githubUrl": "https://github.com/mutual-of-enumclaw/serverless-plugin-decouple",
+  "status": "active"
+}, {
+  "name": "serverless-docker-artifacts",
+  "description": "Build your artifacts within docker container.",
+  "githubUrl": "https://github.com/Suor/serverless-docker-artifacts",
+  "status": "active"
+}, {
+  "name": "serverless-tesseract",
+  "description": "Add Tesseract OCR Engine to your build.",
+  "githubUrl": "https://github.com/Suor/serverless-tesseract",
+  "status": "active"
+}, {
+  "name": "aws-cognito-idp-userpool-domain",
+  "description": "Manage (add and remove) aws hosted domain on Cognito Userpools",
+  "githubUrl": "https://github.com/rubentrancoso/aws-cognito-idp-userpool-domain",
+  "status": "active"
+}, {
+  "name": "serverless-parcel",
+  "description": "A Serverless plugin to bundle your functions and assets with Parcel Bundler",
+  "githubUrl": "https://github.com/johnagan/serverless-parcel",
+  "status": "active"
+}, {
+  "name": "serverless-vault-plugin",
+  "description": "A Serverless plugin to retrieve passwords from vault and encrypt to kms",
+  "githubUrl": "https://github.com/Rondineli/serverless-vault-plugin",
+  "status": "active"
+}, {
+  "name": "serverless-function-outputs",
+  "description": "Adds function Name and ARN outputs without version suffix",
+  "githubUrl": "https://github.com/RogerBarreto/serverless-function-outputs",
+  "status": "active"
+}, {
+  "name": "serverless-website-domain",
+  "description": "A plugin that creates Route 53 records that point to your Cloudfront hosted static website, including www/non-www redirects.",
+  "githubUrl": "https://github.com/williamsandonz/serverless-website-domain",
+  "status": "active"
+},
   {
     "name": "serverless-output-to-env",
     "description": "A Serverless plugin that writes stack outputs to an .env file during the after:deploy hook.",
@@ -1803,289 +1506,242 @@
     "description": "Create and revoke grants for AWS Lambda functions to use KMS keys.",
     "githubUrl": "https://github.com/deep-security/serverless-kms-grants",
     "status": "active"
-  },
-  {
-    "name": "serverless-rack",
-    "description": "Serverless plugin to deploy Ruby Rack applications (Sinatra/Padrino/Cuba etc.)",
-    "githubUrl": "https://github.com/logandk/serverless-rack",
-    "status": "active"
-  },
-  {
-    "name": "serverless-ruby-package",
-    "description": "Improves packaging and deploying gems for Ruby services",
-    "githubUrl": "https://github.com/joshuaflanagan/serverless-ruby-package",
-    "status": "active"
-  },
-  {
-    "name": "serverless-plugin-parcel",
-    "description": "Serverless Parcel plugin with watch mode and serverless-offline support",
-    "githubUrl": "https://github.com/threadheap/serverless-plugin-parcel",
-    "status": "active"
-  },
-  {
-    "name": "serverless-plugin-tree-shake",
-    "description": "Shake the dependency tree and only package files needed",
-    "githubUrl": "https://github.com/sergioramos/serverless-plugin-tree-shake",
-    "status": "active"
-  },
-  {
-    "name": "serverless-plugin-typescript-express",
-    "description": "Serverless plugin Typescript support with express integration",
-    "githubUrl": "https://github.com/eliasjcjunior/serverless-plugin-typescript-express",
-    "status": "active"
-  },
-  {
-    "name": "serverless-aws-static-file-handler",
-    "description": "An easy way to host the front-end of your web applications on Serverless framework on AWS Lambda along with their APIs written in Serverless.",
-    "githubUrl": "https://github.com/activescott/serverless-aws-static-file-handler",
-    "status": "active"
-  },
-  {
-    "name": "serverless-http-invoker",
-    "description": "Locally invoke Serverless functions via their HTTP event as specified in Serverless.yml. It makes it easy to test not only your handler logic, but also ensures that you have your http events setup properly in serverless.yml without deploying.",
-    "githubUrl": "https://github.com/activescott/serverless-http-invoker",
-    "status": "active"
-  },
-  {
-    "name": "serverless-plugin-cloudwatch-dashboard",
-    "description": "Serverless plugin to generate AWS CloudWatch dashboard for AWS Lambda functions",
-    "githubUrl": "https://github.com/codecentric/serverless-plugin-cloudwatch-dashboard",
-    "status": "active"
-  },
-  {
-    "name": "serverless-create-dynamodb-global-tables-for-cf-stack",
-    "description": "Create and replicate global dynamodb tables",
-    "githubUrl": "https://github.com/Imran99/serverless-create-dynamodb-global-tables-for-cf-stack",
-    "status": "active"
-  },
-  {
-    "name": "serverless-tencent-scf",
-    "description": "Serverless framework provider plugin for Tencent SCF(Serverless Cloud Function)",
-    "githubUrl": "https://github.com/tencentyun/serverless-tencent-cloud-function",
-    "status": "active"
-  },
-  {
-    "name": "serverless-plugin-staging",
-    "description": "A plugin to restrict the deployment of resources or functions on a per stage basis",
-    "githubUrl": "https://github.com/icarus-sullivan/serverless-plugin-staging",
-    "status": "active"
-  },
-  {
-    "name": "serverless-fargate-tasks",
-    "description": "A plugin to run fargate tasks as part of your Serverless project",
-    "githubUrl": "https://github.com/svdgraaf/serverless-fargate-tasks",
-    "status": "active"
-  },
-  {
-    "name": "serverless-plugin-composed-vars",
-    "description": "A plugin that composes custom and environment variables based on the deployment stage",
-    "githubUrl": "https://github.com/chris-feist/serverless-plugin-composed-vars",
-    "status": "active"
-  },
-  {
-    "name": "serverless-multi-region-plugin",
-    "description": "A plugin for setting up a serverless API in AWS with turnkey multi-region failover",
-    "githubUrl": "https://github.com/unbill/serverless-multi-region-plugin",
-    "status": "active"
-  },
-  {
-    "name": "serverless-plugin-pubsub",
-    "description": "Simple pub/sub configuration with queueing for the Serverless Framework",
-    "githubUrl": "https://github.com/fivepapertigers/serverless-plugin-pubsub",
-    "status": "active"
-  },
-  {
-    "name": "serverless-import-apigateway",
-    "description": "Dynamically import an existing AWS API Gateway into your Serverless stack",
-    "githubUrl": "https://github.com/mikesouza/serverless-import-apigateway",
-    "status": "active"
-  },
-  {
-    "name": "serverless-associate-waf",
-    "description": "Associate a regional WAF with the AWS API Gateway used by your Serverless stack",
-    "githubUrl": "https://github.com/mikesouza/serverless-associate-waf",
-    "status": "active"
-  },
-  {
-    "name": "serverless-deployment-bucket",
-    "description": "Create and configure the custom Serverless deployment bucket",
-    "githubUrl": "https://github.com/mikesouza/serverless-deployment-bucket",
-    "status": "active"
-  },
-  {
-    "name": "serverless-manifest-plugin",
-    "description": "Generate manifest of api endpoints & stack outputs for consumption in other applications + service discovery",
-    "githubUrl": "https://github.com/DavidWells/serverless-manifest-plugin",
-    "status": "active"
-  },
-  {
-    "name": "serverless-local-kinesis",
-    "description": "Run a local kinesis and automatically fire events",
-    "githubUrl": "https://github.com/pidz-development/serverless-local-kinesis",
-    "status": "active"
-  },
-  {
-    "name": "serverless-nextjs-plugin",
-    "description": "Deploy serverless next apps with ease",
-    "githubUrl": "https://github.com/danielcondemarin/serverless-nextjs-plugin",
-    "status": "active"
-  },
-  {
-    "name": "serverless-plugin-tables",
-    "description": "Easily configure table resources, such as DynamoDB",
-    "githubUrl": "https://github.com/chris-feist/serverless-plugin-tables",
-    "status": "active"
-  },
-  {
-    "name": "serverless-iopipe-layers",
-    "description": "Monitor, observe and profile your AWS Lambda functions without a code change",
-    "githubUrl": "https://github.com/iopipe/serverless-iopipe-layers",
-    "status": "active"
-  },
-  {
-    "name": "serverless-cloudside-plugin",
-    "description": "Easily reference and use cloudside resources during local development and testing",
-    "githubUrl": "https://github.com/jeremydaly/serverless-cloudside-plugin",
-    "status": "active"
-  },
-  {
-    "name": "serverless-jetpack",
-    "description": "A faster JavaScript packager for Serverless applications",
-    "githubUrl": "https://github.com/FormidableLabs/serverless-jetpack",
-    "status": "active"
-  },
-  {
-    "name": "serverless-offline-http-mock",
-    "description": "Create mock responses to HTTP(S) requests for local development",
-    "githubUrl": "https://github.com/pianomansam/serverless-offline-http-mock",
-    "status": "active"
-  },
-  {
-    "name": "serverless-externals-plugin",
-    "description": "Only include listed node modules and their dependencies in Serverless, with support for Rollup and Webpack",
-    "githubUrl": "https://github.com/hansottowirtz/serverless-externals-plugin",
-    "status": "active"
-  },
-  {
-    "name": "api-gateway-stage-tag-plugin",
-    "description": "A shim to tag API Gateway stages until CloudFormation/Serverless support arrives.",
-    "githubUrl": "https://github.com/mikepatrick/api-gateway-stage-tag-plugin",
-    "status": "active"
-  },
-  {
-    "name": "serverless-api-compression",
-    "description": "Serverless plugin that enables/disables content compression setting in API Gateway",
-    "githubUrl": "https://github.com/evgenykireev/serverless-api-compression",
-    "status": "active"
-  },
-  {
-    "name": "serverless-aws-documentation",
-    "description": "Serverless 1.0 plugin to add documentation and models to the serverless generated API Gateway",
-    "githubUrl": "https://github.com/deliveryhero/serverless-aws-documentation",
-    "status": "active"
-  },
-  {
-    "name": "serverless-http",
-    "description": "Use your existing middleware framework (e.g. Express, Koa) in AWS Lambda",
-    "githubUrl": "https://github.com/dougmoscrop/serverless-http",
-    "status": "active"
-  },
-  {
-    "name": "serverless-snowflake-external-function-plugin",
-    "description": "Serverless Plugin for deploying Snowflake External Functions",
-    "githubUrl": "https://github.com/starschema/serverless-snowflake-external-function-plugin",
-    "status": "active"
-  },
-  {
-    "name": "serverless-mysql",
-    "description": "A module for managing MySQL connections at SERVERLESS scale",
-    "githubUrl": "https://github.com/jeremydaly/serverless-mysql",
-    "status": "active"
-  },
-  {
-    "name": "serverless-offline-kinesis",
-    "description": "This Serverless-offline-kinesis plugin emulates AWS λ and Kinesis streams on your local machine.",
-    "githubUrl": "https://github.com/CoorpAcademy/serverless-plugins/tree/master/packages/serverless-offline-kinesis",
-    "status": "active"
-  },
-  {
-    "name": "serverless-offline-python",
-    "description": "Emulate AWS λ and API Gateway locally when developing your Serverless project",
-    "githubUrl": "https://github.com/alhazmy13/serverless-offline-python",
-    "status": "active"
-  },
-  {
-    "name": "serverless-openapi-documentation",
-    "description": "Serverless 1.0 plugin to generate OpenAPI V3 documentation from serverless configuration",
-    "githubUrl": "https://github.com/temando/serverless-openapi-documentation",
-    "status": "active"
-  },
-  {
-    "name": "serverless-openwhisk",
-    "description": "Adds Apache OpenWhisk support to the Serverless Framework!",
-    "githubUrl": "https://github.com/serverless/serverless-openwhisk",
-    "status": "active"
-  },
-  {
-    "name": "serverless-plugin-cloudfront-lambda-edge",
-    "description": "Adds Lambda@Edge support to Serverless",
-    "githubUrl": "https://github.com/silvermine/serverless-plugin-cloudfront-lambda-edge",
-    "status": "active"
-  },
-  {
-    "name": "serverless-plugin-cronjob",
-    "description": "This plugin creates cronjobs out of your lambda functions.",
-    "githubUrl": "https://github.com/martinlindenberg/serverless-plugin-cronjob",
-    "status": "active"
-  },
-  {
-    "name": "serverless-plugin-custom-roles",
-    "description": "A Serverless plugin that makes creation of per function IAM roles easier.",
-    "githubUrl": "https://github.com/AntonBazhal/serverless-plugin-custom-roles",
-    "status": "active"
-  },
-  {
-    "name": "serverless-plugin-existing-s3",
-    "description": "Overcomes the CloudFormation limitation on attaching an event to an uncontrolled bucket, for Serverless.com 1.11.0+.",
-    "githubUrl": "https://github.com/matt-filion/serverless-external-s3-event",
-    "status": "active"
-  },
-  {
-    "name": "serverless-plugin-log-retention",
-    "description": "Control the retention of your serverless function's cloudwatch logs.",
-    "githubUrl": "https://github.com/ArtificerEntertainment/serverless-plugin-log-retention",
-    "status": "active"
-  },
-  {
-    "name": "serverless-plugin-newman",
-    "description": "A serverless plugin for newman.",
-    "githubUrl": "https://github.com/rawphp/serverless-plugin-newman",
-    "status": "active"
-  },
-  {
-    "name": "serverless-plugin-tracing",
-    "description": "Enables AWS X-Ray (https://aws.amazon.com/xray/) for the entire Serverless stack or individual functions.",
-    "githubUrl": "https://github.com/alex-murashkin/serverless-plugin-tracing",
-    "status": "active"
-  },
-  {
-    "name": "serverless-s3-deploy",
-    "description": "Plugin for serverless to deploy files to a variety of S3 Buckets",
-    "githubUrl": "https://github.com/funkybob/serverless-s3-deploy",
-    "status": "active"
-  },
-  {
-    "name": "serverless-scheduled-functions",
-    "description": "Schedule your serverless functions",
-    "githubUrl": "https://github.com/reactor-studio/serverless-scheduled-functions",
-    "status": "active"
-  },
-  {
-    "name": "serverless-step-functions-offline",
-    "description": "Emulate step functions locally when developing your Serverless project ",
-    "githubUrl": "https://github.com/vkkis93/serverless-step-functions-offline",
-    "status": "active"
-  },
+  }, {
+  "name": "serverless-rack",
+  "description": "Serverless plugin to deploy Ruby Rack applications (Sinatra/Padrino/Cuba etc.)",
+  "githubUrl": "https://github.com/logandk/serverless-rack",
+  "status": "active"
+}, {
+  "name": "serverless-ruby-package",
+  "description": "Improves packaging and deploying gems for Ruby services",
+  "githubUrl": "https://github.com/joshuaflanagan/serverless-ruby-package",
+  "status": "active"
+}, {
+  "name": "serverless-plugin-parcel",
+  "description": "Serverless Parcel plugin with watch mode and serverless-offline support",
+  "githubUrl": "https://github.com/threadheap/serverless-plugin-parcel",
+  "status": "active"
+}, {
+  "name": "serverless-plugin-tree-shake",
+  "description": "Shake the dependency tree and only package files needed",
+  "githubUrl": "https://github.com/sergioramos/serverless-plugin-tree-shake",
+  "status": "active"
+}, {
+  "name": "serverless-plugin-typescript-express",
+  "description": "Serverless plugin Typescript support with express integration",
+  "githubUrl": "https://github.com/eliasjcjunior/serverless-plugin-typescript-express",
+  "status": "active"
+}, {
+  "name": "serverless-aws-static-file-handler",
+  "description": "An easy way to host the front-end of your web applications on Serverless framework on AWS Lambda along with their APIs written in Serverless.",
+  "githubUrl": "https://github.com/activescott/serverless-aws-static-file-handler",
+  "status": "active"
+}, {
+  "name": "serverless-http-invoker",
+  "description": "Locally invoke Serverless functions via their HTTP event as specified in Serverless.yml. It makes it easy to test not only your handler logic, but also ensures that you have your http events setup properly in serverless.yml without deploying.",
+  "githubUrl": "https://github.com/activescott/serverless-http-invoker",
+  "status": "active"
+}, {
+  "name": "serverless-plugin-cloudwatch-dashboard",
+  "description": "Serverless plugin to generate AWS CloudWatch dashboard for AWS Lambda functions",
+  "githubUrl": "https://github.com/codecentric/serverless-plugin-cloudwatch-dashboard",
+  "status": "active"
+}, {
+  "name": "serverless-create-dynamodb-global-tables-for-cf-stack",
+  "description": "Create and replicate global dynamodb tables",
+  "githubUrl": "https://github.com/Imran99/serverless-create-dynamodb-global-tables-for-cf-stack",
+  "status": "active"
+}, {
+  "name": "serverless-tencent-scf",
+  "description": "Serverless framework provider plugin for Tencent SCF(Serverless Cloud Function)",
+  "githubUrl": "https://github.com/tencentyun/serverless-tencent-cloud-function",
+  "status": "active"
+}, {
+  "name": "serverless-plugin-staging",
+  "description": "A plugin to restrict the deployment of resources or functions on a per stage basis",
+  "githubUrl": "https://github.com/icarus-sullivan/serverless-plugin-staging",
+  "status": "active"
+}, {
+  "name": "serverless-fargate-tasks",
+  "description": "A plugin to run fargate tasks as part of your Serverless project",
+  "githubUrl": "https://github.com/svdgraaf/serverless-fargate-tasks",
+  "status": "active"
+}, {
+  "name": "serverless-plugin-composed-vars",
+  "description": "A plugin that composes custom and environment variables based on the deployment stage",
+  "githubUrl": "https://github.com/chris-feist/serverless-plugin-composed-vars",
+  "status": "active"
+}, {
+  "name": "serverless-multi-region-plugin",
+  "description": "A plugin for setting up a serverless API in AWS with turnkey multi-region failover",
+  "githubUrl": "https://github.com/unbill/serverless-multi-region-plugin",
+  "status": "active"
+}, {
+  "name": "serverless-plugin-pubsub",
+  "description": "Simple pub/sub configuration with queueing for the Serverless Framework",
+  "githubUrl": "https://github.com/fivepapertigers/serverless-plugin-pubsub",
+  "status": "active"
+}, {
+  "name": "serverless-import-apigateway",
+  "description": "Dynamically import an existing AWS API Gateway into your Serverless stack",
+  "githubUrl": "https://github.com/mikesouza/serverless-import-apigateway",
+  "status": "active"
+}, {
+  "name": "serverless-associate-waf",
+  "description": "Associate a regional WAF with the AWS API Gateway used by your Serverless stack",
+  "githubUrl": "https://github.com/mikesouza/serverless-associate-waf",
+  "status": "active"
+}, {
+  "name": "serverless-deployment-bucket",
+  "description": "Create and configure the custom Serverless deployment bucket",
+  "githubUrl": "https://github.com/mikesouza/serverless-deployment-bucket",
+  "status": "active"
+}, {
+  "name": "serverless-manifest-plugin",
+  "description": "Generate manifest of api endpoints & stack outputs for consumption in other applications + service discovery",
+  "githubUrl": "https://github.com/DavidWells/serverless-manifest-plugin",
+  "status": "active"
+}, {
+  "name": "serverless-local-kinesis",
+  "description": "Run a local kinesis and automatically fire events",
+  "githubUrl": "https://github.com/pidz-development/serverless-local-kinesis",
+  "status": "active"
+}, {
+  "name": "serverless-nextjs-plugin",
+  "description": "Deploy serverless next apps with ease",
+  "githubUrl": "https://github.com/danielcondemarin/serverless-nextjs-plugin",
+  "status": "active"
+}, {
+  "name": "serverless-plugin-tables",
+  "description": "Easily configure table resources, such as DynamoDB",
+  "githubUrl": "https://github.com/chris-feist/serverless-plugin-tables",
+  "status": "active"
+}, {
+  "name": "serverless-iopipe-layers",
+  "description": "Monitor, observe and profile your AWS Lambda functions without a code change",
+  "githubUrl": "https://github.com/iopipe/serverless-iopipe-layers",
+  "status": "active"
+}, {
+  "name": "serverless-cloudside-plugin",
+  "description": "Easily reference and use cloudside resources during local development and testing",
+  "githubUrl": "https://github.com/jeremydaly/serverless-cloudside-plugin",
+  "status": "active"
+}, {
+  "name": "serverless-jetpack",
+  "description": "A faster JavaScript packager for Serverless applications",
+  "githubUrl": "https://github.com/FormidableLabs/serverless-jetpack",
+  "status": "active"
+}, {
+  "name": "serverless-offline-http-mock",
+  "description": "Create mock responses to HTTP(S) requests for local development",
+  "githubUrl": "https://github.com/pianomansam/serverless-offline-http-mock",
+  "status": "active"
+}, {
+  "name": "serverless-externals-plugin",
+  "description": "Only include listed node modules and their dependencies in Serverless, with support for Rollup and Webpack",
+  "githubUrl": "https://github.com/hansottowirtz/serverless-externals-plugin",
+  "status": "active"
+}, {
+  "name": "api-gateway-stage-tag-plugin",
+  "description": "A shim to tag API Gateway stages until CloudFormation/Serverless support arrives.",
+  "githubUrl": "https://github.com/mikepatrick/api-gateway-stage-tag-plugin",
+  "status": "active"
+}, {
+  "name": "serverless-api-compression",
+  "description": "Serverless plugin that enables/disables content compression setting in API Gateway",
+  "githubUrl": "https://github.com/evgenykireev/serverless-api-compression",
+  "status": "active"
+}, {
+  "name": "serverless-aws-documentation",
+  "description": "Serverless 1.0 plugin to add documentation and models to the serverless generated API Gateway",
+  "githubUrl": "https://github.com/deliveryhero/serverless-aws-documentation",
+  "status": "active"
+}, {
+  "name": "serverless-http",
+  "description": "Use your existing middleware framework (e.g. Express, Koa) in AWS Lambda",
+  "githubUrl": "https://github.com/dougmoscrop/serverless-http",
+  "status": "active"
+}, {
+  "name": "serverless-snowflake-external-function-plugin",
+  "description": "Serverless Plugin for deploying Snowflake External Functions",
+  "githubUrl": "https://github.com/starschema/serverless-snowflake-external-function-plugin",
+  "status": "active"
+}, {
+  "name": "serverless-mysql",
+  "description": "A module for managing MySQL connections at SERVERLESS scale",
+  "githubUrl": "https://github.com/jeremydaly/serverless-mysql",
+  "status": "active"
+}, {
+  "name": "serverless-offline-kinesis",
+  "description": "This Serverless-offline-kinesis plugin emulates AWS λ and Kinesis streams on your local machine.",
+  "githubUrl": "https://github.com/CoorpAcademy/serverless-plugins/tree/master/packages/serverless-offline-kinesis",
+  "status": "active"
+}, {
+  "name": "serverless-offline-python",
+  "description": "Emulate AWS λ and API Gateway locally when developing your Serverless project",
+  "githubUrl": "https://github.com/alhazmy13/serverless-offline-python",
+  "status": "active"
+}, {
+  "name": "serverless-openapi-documentation",
+  "description": "Serverless 1.0 plugin to generate OpenAPI V3 documentation from serverless configuration",
+  "githubUrl": "https://github.com/temando/serverless-openapi-documentation",
+  "status": "active"
+}, {
+  "name": "serverless-openwhisk",
+  "description": "Adds Apache OpenWhisk support to the Serverless Framework!",
+  "githubUrl": "https://github.com/serverless/serverless-openwhisk",
+  "status": "active"
+}, {
+  "name": "serverless-plugin-cloudfront-lambda-edge",
+  "description": "Adds Lambda@Edge support to Serverless",
+  "githubUrl": "https://github.com/silvermine/serverless-plugin-cloudfront-lambda-edge",
+  "status": "active"
+}, {
+  "name": "serverless-plugin-cronjob",
+  "description": "This plugin creates cronjobs out of your lambda functions.",
+  "githubUrl": "https://github.com/martinlindenberg/serverless-plugin-cronjob",
+  "status": "active"
+}, {
+  "name": "serverless-plugin-custom-roles",
+  "description": "A Serverless plugin that makes creation of per function IAM roles easier.",
+  "githubUrl": "https://github.com/AntonBazhal/serverless-plugin-custom-roles",
+  "status": "active"
+}, {
+  "name": "serverless-plugin-existing-s3",
+  "description": "Overcomes the CloudFormation limitation on attaching an event to an uncontrolled bucket, for Serverless.com 1.11.0+.",
+  "githubUrl": "https://github.com/matt-filion/serverless-external-s3-event",
+  "status": "active"
+}, {
+  "name": "serverless-plugin-log-retention",
+  "description": "Control the retention of your serverless function's cloudwatch logs.",
+  "githubUrl": "https://github.com/ArtificerEntertainment/serverless-plugin-log-retention",
+  "status": "active"
+}, {
+  "name": "serverless-plugin-newman",
+  "description": "A serverless plugin for newman.",
+  "githubUrl": "https://github.com/rawphp/serverless-plugin-newman",
+  "status": "active"
+}, {
+  "name": "serverless-plugin-tracing",
+  "description": "Enables AWS X-Ray (https://aws.amazon.com/xray/) for the entire Serverless stack or individual functions.",
+  "githubUrl": "https://github.com/alex-murashkin/serverless-plugin-tracing",
+  "status": "active"
+}, {
+  "name": "serverless-s3-deploy",
+  "description": "Plugin for serverless to deploy files to a variety of S3 Buckets",
+  "githubUrl": "https://github.com/funkybob/serverless-s3-deploy",
+  "status": "active"
+}, {
+  "name": "serverless-scheduled-functions",
+  "description": "Schedule your serverless functions",
+  "githubUrl": "https://github.com/reactor-studio/serverless-scheduled-functions",
+  "status": "active"
+}, {
+  "name": "serverless-step-functions-offline",
+  "description": "Emulate step functions locally when developing your Serverless project ",
+  "githubUrl": "https://github.com/vkkis93/serverless-step-functions-offline",
+  "status": "active"
+},
   {
     "name": "serverless-configuration",
     "description": "Easily customize serverless.yml depending on the stage or whether running online/offline",

--- a/plugins.json
+++ b/plugins.json
@@ -1,1747 +1,1747 @@
 [{
-  "name": "@kakkuk/serverless-aws-lambda-dynamic-trigger",
-  "description": "Allows to register sns, sqs and kinesis triggers (events) dynamically.",
-  "githubUrl": "https://github.com/failsafe-engineering/serverless-aws-lambda-dynamic-trigger",
-  "status": "active"
+    "name": "@kakkuk/serverless-aws-lambda-dynamic-trigger",
+    "description": "Allows to register sns, sqs and kinesis triggers (events) dynamically.",
+    "githubUrl": "https://github.com/failsafe-engineering/serverless-aws-lambda-dynamic-trigger",
+    "status": "active"
 },{
-  "name": "@kakkuk/serverless-aws-apigateway-documentation",
-  "description": "Adds support for AWS API Gateway documentation and model",
-  "githubUrl": "https://github.com/failsafe-engineering/serverless-aws-apigateway-documentation",
-  "status": "active"
+    "name": "@kakkuk/serverless-aws-apigateway-documentation",
+    "description": "Adds support for AWS API Gateway documentation and model",
+    "githubUrl": "https://github.com/failsafe-engineering/serverless-aws-apigateway-documentation",
+    "status": "active"
 },{
-  "name": "@vulcancreative/serverless-storage",
-  "description": "Serverless plugin defining DynamoDB storage primitives; like localStorage but better",
-  "githubUrl": "https://github.com/vulcancreative/serverless-storage",
-  "status": "active"
+    "name": "@vulcancreative/serverless-storage",
+    "description": "Serverless plugin defining DynamoDB storage primitives; like localStorage but better",
+    "githubUrl": "https://github.com/vulcancreative/serverless-storage",
+    "status": "active"
 },{
-  "name": "serverless-aws-function-url-custom-domain",
-  "description": "Setup cloudfront distrubution and route53 record for AWS Lambda with Function URL",
-  "githubUrl": "https://github.com/wangsha/serverless-aws-function-url-custom-domain",
-  "status": "active"
+    "name": "serverless-aws-function-url-custom-domain",
+    "description": "Setup cloudfront distrubution and route53 record for AWS Lambda with Function URL",
+    "githubUrl": "https://github.com/wangsha/serverless-aws-function-url-custom-domain",
+    "status": "active"
 },{
-  "name": "serverless-plugin-typetalk",
-  "description": "Sends notification to Typetalk",
-  "githubUrl": "https://github.com/is2ei/serverless-plugin-typetalk",
-  "status": "active"
+    "name": "serverless-plugin-typetalk",
+    "description": "Sends notification to Typetalk",
+    "githubUrl": "https://github.com/is2ei/serverless-plugin-typetalk",
+    "status": "active"
 }, {
-  "name": "serverless-aws-lambda",
-  "description": "Plug & Play AWS Lambda NodeJS development tool with local API Gateway and Application Load Balancer support.",
-  "githubUrl": "https://github.com/Inqnuam/serverless-aws-lambda",
-  "status": "active"
+    "name": "serverless-aws-lambda",
+    "description": "Plug & Play AWS Lambda NodeJS development tool with local API Gateway and Application Load Balancer support.",
+    "githubUrl": "https://github.com/Inqnuam/serverless-aws-lambda",
+    "status": "active"
 },{
-  "name": "serverless-app-client-credentials-to-ssm",
-  "description": "Export Cognito app client credentials to SSM Parameter store",
-  "githubUrl": "https://github.com/GaaraZhu/serverless-app-client-credentials-to-ssm",
-  "status": "active"
+    "name": "serverless-app-client-credentials-to-ssm",
+    "description": "Export Cognito app client credentials to SSM Parameter store",
+    "githubUrl": "https://github.com/GaaraZhu/serverless-app-client-credentials-to-ssm",
+    "status": "active"
 }, {
-  "name": "serverless-prune-versions",
-  "description": "Automatic deletion of old Lambda and Lambda Layer versions",
-  "githubUrl": "https://github.com/manwaring/serverless-prune-versions",
-  "status": "active"
+    "name": "serverless-prune-versions",
+    "description": "Automatic deletion of old Lambda and Lambda Layer versions",
+    "githubUrl": "https://github.com/manwaring/serverless-prune-versions",
+    "status": "active"
 }, {
-  "name": "serverless-log-metric-filter",
-  "description": "Add Cloudwatch Log Metric Filter to Cloudwatch Logs",
-  "githubUrl": "https://github.com/saqemlas/serverless-log-metric-filter",
-  "status": "active"
+    "name": "serverless-log-metric-filter",
+    "description": "Add Cloudwatch Log Metric Filter to Cloudwatch Logs",
+    "githubUrl": "https://github.com/saqemlas/serverless-log-metric-filter",
+    "status": "active"
 },
-  {
+{
     "name": "serverless-plugin-sumologic",
     "description": "This Serverless plugin deploys Cloudformation Stack with resources required to send Cloudformation Logs to Sumologic. This stack uses AWS Lambda to subscribe to your CloudWatch Log Group and POSTs the log data directly to Sumo HTTP Source.",
     "githubUrl": "https://github.com/ACloudGuru/serverless-plugin-sumologic",
     "status": "active"
-  }, {
-  "name": "serverless-plugin-apollo-graphql-federation",
-  "description": "A Serverless Framework that uploads a graphql schema to the Apollo Platform managed federation service",
-  "githubUrl": "https://github.com/Imran99/serverless-plugin-apollo-graphql-federation",
-  "status": "active"
 }, {
-  "name": "serverless-plugin-modularize",
-  "description": "Modularize your serverless definitions",
-  "githubUrl": "https://github.com/icarus-sullivan/serverless-plugin-modularize",
-  "status": "active"
+    "name": "serverless-plugin-apollo-graphql-federation",
+    "description": "A Serverless Framework that uploads a graphql schema to the Apollo Platform managed federation service",
+    "githubUrl": "https://github.com/Imran99/serverless-plugin-apollo-graphql-federation",
+    "status": "active"
 }, {
-  "name": "@stratiformdigital/serverless-online",
-  "description": "Faster lambda development in AWS through hot deploys and streaming logs.",
-  "githubUrl": "https://github.com/stratiformdigital/serverless-online",
-  "status": "active"
+    "name": "serverless-plugin-modularize",
+    "description": "Modularize your serverless definitions",
+    "githubUrl": "https://github.com/icarus-sullivan/serverless-plugin-modularize",
+    "status": "active"
 }, {
-  "name": "@stratiformdigital/serverless-iam-helper",
-  "description": "Applies IAM Path and PermissionsBoundary settings in hard to reach places.",
-  "githubUrl": "https://github.com/stratiformdigital/serverless-iam-helper",
-  "status": "active"
+    "name": "@stratiformdigital/serverless-online",
+    "description": "Faster lambda development in AWS through hot deploys and streaming logs.",
+    "githubUrl": "https://github.com/stratiformdigital/serverless-online",
+    "status": "active"
 }, {
-  "name": "@stratiformdigital/serverless-idempotency-helper",
-  "description": "Helps make lambda deployments idempotent",
-  "githubUrl": "https://github.com/stratiformdigital/serverless-idempotency-helper",
-  "status": "active"
+    "name": "@stratiformdigital/serverless-iam-helper",
+    "description": "Applies IAM Path and PermissionsBoundary settings in hard to reach places.",
+    "githubUrl": "https://github.com/stratiformdigital/serverless-iam-helper",
+    "status": "active"
 }, {
-  "name": "@stratiformdigital/serverless-s3-security-helper",
-  "description": "Sets security minded settings on s3 buckets, including sls deployment buckets",
-  "githubUrl": "https://github.com/stratiformdigital/serverless-s3-security-helper",
-  "status": "active"
+    "name": "@stratiformdigital/serverless-idempotency-helper",
+    "description": "Helps make lambda deployments idempotent",
+    "githubUrl": "https://github.com/stratiformdigital/serverless-idempotency-helper",
+    "status": "active"
 }, {
-  "name": "serverless-provisioned-concurrency-autoscaling",
-  "description": "Serverless Plugin for AWS Lambda Provisioned Concurrency Auto Scaling configuration",
-  "githubUrl": "https://github.com/neiman-marcus/serverless-provisioned-concurrency-autoscaling",
-  "status": "active"
+    "name": "@stratiformdigital/serverless-s3-security-helper",
+    "description": "Sets security minded settings on s3 buckets, including sls deployment buckets",
+    "githubUrl": "https://github.com/stratiformdigital/serverless-s3-security-helper",
+    "status": "active"
 }, {
-  "name": "serverless-localstack",
-  "description": "Serverless plugin for LocalStack - a fully functional local AWS cloud stack. Develop and test your cloud & Serverless apps offline!",
-  "githubUrl": "https://github.com/LocalStack/serverless-localstack",
-  "status": "active"
+    "name": "serverless-provisioned-concurrency-autoscaling",
+    "description": "Serverless Plugin for AWS Lambda Provisioned Concurrency Auto Scaling configuration",
+    "githubUrl": "https://github.com/neiman-marcus/serverless-provisioned-concurrency-autoscaling",
+    "status": "active"
 }, {
-  "name": "serverless-commercetools-plugin",
-  "description": "Serverless framework plugin that registers the deployed function as a commercetools API Extension or attaches it to a Subscription.",
-  "githubUrl": "https://github.com/commercetools/serverless-commercetools-plugin",
-  "status": "active"
+    "name": "serverless-localstack",
+    "description": "Serverless plugin for LocalStack - a fully functional local AWS cloud stack. Develop and test your cloud & Serverless apps offline!",
+    "githubUrl": "https://github.com/LocalStack/serverless-localstack",
+    "status": "active"
 }, {
-  "name": "serverless-plugin-test-helper",
-  "description": "Makes it easier to end-to-end test deployed deployed services by saving CloudFormation Stack Outputs locally and exposing values via a simple Node.js library",
-  "githubUrl": "https://github.com/manwaring/serverless-plugin-test-helper",
-  "status": "active"
+    "name": "serverless-commercetools-plugin",
+    "description": "Serverless framework plugin that registers the deployed function as a commercetools API Extension or attaches it to a Subscription.",
+    "githubUrl": "https://github.com/commercetools/serverless-commercetools-plugin",
+    "status": "active"
 }, {
-  "name": "serverless-plugin-dart",
-  "description": "Deploy Dart applications to AWS Lambda",
-  "githubUrl": "https://github.com/katallaxie/serverless-dart",
-  "status": "active"
+    "name": "serverless-plugin-test-helper",
+    "description": "Makes it easier to end-to-end test deployed deployed services by saving CloudFormation Stack Outputs locally and exposing values via a simple Node.js library",
+    "githubUrl": "https://github.com/manwaring/serverless-plugin-test-helper",
+    "status": "active"
 }, {
-  "name": "serverless-scaleway-serverless",
-  "description": "This plugin enables support for Scaleway Serverless Functions and Serverless Containers betas within the Serverless Framework",
-  "githubUrl": "https://github.com/scaleway/serverless-scaleway-functions",
-  "status": "active"
+    "name": "serverless-plugin-dart",
+    "description": "Deploy Dart applications to AWS Lambda",
+    "githubUrl": "https://github.com/katallaxie/serverless-dart",
+    "status": "active"
 }, {
-  "name": "serverless-plugin-iam-checker",
-  "description": "Helps automate security controls by preventing overly broad IAM permissions via customizable rules for both actions and resource references. Ships with restrictive defaults and supports custom rule configurations via serverless.yml and environment variables",
-  "githubUrl": "https://github.com/manwaring/serverless-plugin-iam-checker",
-  "status": "active"
+    "name": "serverless-scaleway-serverless",
+    "description": "This plugin enables support for Scaleway Serverless Functions and Serverless Containers betas within the Serverless Framework",
+    "githubUrl": "https://github.com/scaleway/serverless-scaleway-functions",
+    "status": "active"
 }, {
-  "name": "serverless-plugin-layer-manager",
-  "description": "Plugin for improved AWS Lambda layer management, including install hooks, export options and improved retain support",
-  "githubUrl": "https://github.com/henhal/serverless-plugin-layer-manager",
-  "status": "active"
+    "name": "serverless-plugin-iam-checker",
+    "description": "Helps automate security controls by preventing overly broad IAM permissions via customizable rules for both actions and resource references. Ships with restrictive defaults and supports custom rule configurations via serverless.yml and environment variables",
+    "githubUrl": "https://github.com/manwaring/serverless-plugin-iam-checker",
+    "status": "active"
 }, {
-  "name": "serverless-plugin-lambda-edge",
-  "description": "Plugin for Lambda@Edge, just associating your Lambda function with existing CloudFront distribution via AWS SDK",
-  "githubUrl": "https://github.com/isudzumi/serverless-plugin-lambda-edge",
-  "status": "active"
+    "name": "serverless-plugin-layer-manager",
+    "description": "Plugin for improved AWS Lambda layer management, including install hooks, export options and improved retain support",
+    "githubUrl": "https://github.com/henhal/serverless-plugin-layer-manager",
+    "status": "active"
 }, {
-  "name": "serverless-export-outputs",
-  "description": "A Serverless plugin for exporting AWS stack outputs to a file",
-  "githubUrl": "https://github.com/honarpour/serverless-export-outputs",
-  "status": "active"
+    "name": "serverless-plugin-lambda-edge",
+    "description": "Plugin for Lambda@Edge, just associating your Lambda function with existing CloudFront distribution via AWS SDK",
+    "githubUrl": "https://github.com/isudzumi/serverless-plugin-lambda-edge",
+    "status": "active"
 }, {
-  "name": "serverless-plugin-apigateway-sqs",
-  "description": "Plugin that creates an AWS APIGateway resource to connect to an AWS Simple Queue Service (SQS) without the use of a lambda.",
-  "githubUrl": "https://github.com/CodeRecipe-dev/serverless-apigw-sqs-plugin",
-  "status": "active"
+    "name": "serverless-export-outputs",
+    "description": "A Serverless plugin for exporting AWS stack outputs to a file",
+    "githubUrl": "https://github.com/honarpour/serverless-export-outputs",
+    "status": "active"
+}, {
+    "name": "serverless-plugin-apigateway-sqs",
+    "description": "Plugin that creates an AWS APIGateway resource to connect to an AWS Simple Queue Service (SQS) without the use of a lambda.",
+    "githubUrl": "https://github.com/CodeRecipe-dev/serverless-apigw-sqs-plugin",
+    "status": "active"
 }, {
   "name": "serverless-mongodb-local",
   "description": "Serverless MongoDB local plugin",
   "githubUrl": "https://github.com/bealearts/serverless-mongodb-local",
   "status": "active"
 }, {
-  "name": "serverless-plugin-utils",
-  "description": "A collection of serverless framework utilities",
-  "githubUrl": "https://github.com/icarus-sullivan/serverless-plugin-utils",
-  "status": "active"
-}, {
-  "name": "serverless-layers",
-  "description": "How to reduce drastically lambda size",
-  "githubUrl": "https://github.com/agutoli/serverless-layers",
-  "status": "active"
-}, {
-  "name": "mfa-serverless-plugin",
-  "description": "A simple plugin for deployment accounts with MFA",
-  "githubUrl": "https://github.com/alikian/mfa-serverless-plugin",
-  "status": "active"
-}, {
-  "name": "serverless-ini-env",
-  "description": "Nice Serverless plugin to setup environment variables with ini file",
-  "githubUrl": "https://github.com/agutoli/serverless-ini-env",
-  "status": "active"
-}, {
-  "name": "serverless-websockets-plugin",
-  "description": "Websocket support for Serverless Framework on AWS",
-  "githubUrl": "https://github.com/serverless/serverless-websockets-plugin",
-  "status": "active"
-}, {
-  "name": "serverless-resource-policy",
-  "description": "Creates a whitelist of IP or CIDR addresses using serverless resource policies",
-  "githubUrl": "https://github.com/HubSpotWebTeam/serverless-resource-policy",
-  "status": "active"
-}, {
-  "name": "serverless-plugin-vault-v2",
-  "description": "Simplify integration between serverless and vault to storage environments variables",
-  "githubUrl": "https://github.com/eliasjcjunior/serverless-plugin-vault-v2",
-  "status": "active"
-}, {
-  "name": "serverless-plugin-powertools",
-  "description": "Serverless plugin adding several variable tools, resolvers, and commands",
-  "githubUrl": "https://github.com/whardier/serverless-plugin-powertools",
-  "status": "active"
-}, {
-  "name": "serverless-justauthenticateme-plugin",
-  "description": "Use JustAuthenticateMe to easily authenticate users before hitting your lambdas",
-  "githubUrl": "https://github.com/CoalesceSoftware/serverless-justauthenticateme-plugin",
-  "status": "active"
-}, {
-  "name": "serverless-openapi-plugin",
-  "description": "Serverless plugin to generate serverless API architecture from OpenAPI definition.",
-  "githubUrl": "https://github.com/jaumard/serverless-openapi-plugin",
-  "status": "active"
-}, {
-  "name": "serverless-dotenv-plugin",
-  "description": "Preload environment variables from `.env` into serverless.",
-  "githubUrl": "https://github.com/infrontlabs/serverless-dotenv-plugin",
-  "status": "active"
-}, {
-  "name": "serverless-disable-request-validators",
-  "description": "Serverless v2/v3 plugin to disable API Gateway request validators.",
-  "githubUrl": "https://github.com/jweyrich/serverless-disable-request-validators",
-  "status": "active"
-}, {
-  "name": "serverless-default-aws-resource-attributes",
-  "description": "Set default attributes a given CloudFormation resource should have based on type.",
-  "githubUrl": "https://github.com/neverendingqs/serverless-default-aws-resource-attributes",
-  "status": "active"
-}, {
-  "name": "serverless-stack-policy-by-resource-type",
-  "description": "Serverless Framework plugin for automatically populating CloudFormation stack policy statements by resource type.",
-  "githubUrl": "https://github.com/neverendingqs/serverless-stack-policy-by-resource-type",
-  "status": "active"
-}, {
-  "name": "serverless-print-resolved-plugin",
-  "description": "Generate a copy of serverless.yml with all variables resolved.",
-  "githubUrl": "https://github.com/neverendingqs/serverless-print-resolved-plugin",
-  "status": "active"
-}, {
-  "name": "serverless-discovery-plugin",
-  "description": "A serverless plugin to register AWS micro-service endpoints with a discovery service at serverless deploy or serverless remove time.",
-  "githubUrl": "https://github.com/aregier/serverless-discovery-plugin",
-  "status": "active"
-}, {
-  "name": "fullstack-serverless",
-  "description": "A Serverless plugin to create an AWS CloudFront distribution that serves static web content from S3 and routes API traffic to API Gateway.",
-  "githubUrl": "https://github.com/MadSkills-io/fullstack-serverless",
-  "status": "active"
-}, {
-  "name": "serverless-finch",
-  "description": "A Serverless plugin to deploy static website assets to AWS S3.",
-  "githubUrl": "https://github.com/fernando-mc/serverless-finch",
-  "status": "active"
-}, {
-  "name": "serverless-appsync-plugin",
-  "description": "Serverless Plugin to deploy AppSync GraphQL API",
-  "githubUrl": "https://github.com/sid88in/serverless-appsync-plugin",
-  "status": "active"
-}, {
-  "name": "serverless-appsync-simulator",
-  "description": "Offline support for serverless-appsync-plugin",
-  "githubUrl": "https://github.com/bboure/serverless-appsync-simulator",
-  "status": "active"
-}, {
-  "name": "serverless-remote-json-envs",
-  "description": "Allows to use plain JSON files in remote locations being parsed as environment variables in lambda",
-  "githubUrl": "https://github.com/juancarestre/serverless-remote-json-envs",
-  "status": "active"
-}, {
-  "name": "serverless-plugin-tag-cloud-watch-logs",
-  "description": "Small serverless plugin providing a way to add tags to CloudWatch resources",
-  "githubUrl": "https://github.com/pretty-fun-therapy/serverless-plugin-tag-cloud-watch-logs",
-  "status": "active"
-}, {
-  "name": "serverless-appsync-offline",
-  "description": "Serverless Plugin to run AWS AppSync GraphQL API localy with dynamoDB and lambda resolvers",
-  "githubUrl": "https://github.com/aheissenberger/serverless-appsync-offline",
-  "status": "active"
-}, {
-  "name": "aws-amplify-serverless-plugin",
-  "description": "Generate client-side configuration files for the AWS Amplify library based on your deployed Serverless backend",
-  "githubUrl": "https://github.com/awslabs/aws-amplify-serverless-plugin",
-  "status": "active"
-}, {
-  "name": "serverless-amplify-auth",
-  "description": "Update Policy for Amplify's Auth Role and Unauth Role",
-  "githubUrl": "https://github.com/nikaera/serverless-amplify-auth",
-  "status": "active"
-}, {
-  "name": "serverless-cloudformation-parameter-setter",
-  "description": "Set CloudFormation parameters when deploying.",
-  "githubUrl": "https://github.com/trek10inc/serverless-cloudformation-parameter-setter",
-  "status": "active"
-}, {
-  "name": "serverless-alexa-skills",
-  "description": "Manage your Alexa Skills with Serverless Framework.",
-  "githubUrl": "https://github.com/marcy-terui/serverless-alexa-skills",
-  "status": "active"
-}, {
-  "name": "serverless-plugin-chrome",
-  "description": "Plugin which bundles and ensures that Headless Chrome/Chromium is running when your AWS Lambda function handler is invoked.",
-  "githubUrl": "https://github.com/adieuadieu/serverless-chrome/tree/master/packages/serverless-plugin",
-  "status": "active"
-}, {
-  "name": "serverless-ssm-fetch",
-  "description": "Sets \"AWS Systems Manager Parameter Store (SSM)\" parameters into functions' environment variables.",
-  "githubUrl": "https://github.com/gozup/serverless-ssm-fetch",
-  "status": "active"
-}, {
-  "name": "serverless-custom-packaging-plugin",
-  "description": "Plugin to package your sourcecode using a custom target path inside the zip.",
-  "githubUrl": "https://github.com/hypoport/serverless-custom-packaging-plugin",
-  "status": "active"
-}, {
-  "name": "kumologica-serverless-plugin",
-  "description": "Plugin to package and deploy Kumologica flow into AWS",
-  "githubUrl": "https://github.com/KumologicaHQ/kumologica-serverless-plugin"
-}, {
-  "name": "serverless-apigw-binary",
-  "description": "Plugin to enable binary support in AWS API Gateway.",
-  "githubUrl": "https://github.com/maciejtreder/serverless-apigw-binary",
-  "status": "active"
-}, {
-  "name": "serverless-certificate-creator",
-  "description": "This serverless plugin creates certificates that you need for your custom domains in API Gateway.",
-  "githubUrl": "https://github.com/schwamster/serverless-certificate-creator",
-  "status": "active"
-}, {
-  "name": "serverless-apigator",
-  "description": "This serverless plugin enables you to write AWS lambda with typescript using Microgamma",
-  "githubUrl": "https://github.com/microgamma/microgamma",
-  "status": "active"
-}, {
-  "name": "serverless-plugin-1password",
-  "description": "Serverless interface to 1Password data via the 1Password CLI",
-  "githubUrl": "https://github.com/kandsten/serverless-plugin-1password",
-  "status": "active"
-}, {
-  "name": "serverless-log-filter-subscription",
-  "description": "This serverless plugin creates log filter subscription for all lambda functions configured in your projects serverless.yml",
-  "githubUrl": "https://github.com/schwamster/serverless-log-filter-subscription",
-  "status": "active"
-}, {
-  "name": "serverless-domain-manager",
-  "description": "Serverless plugin for managing custom domains with API Gateways.",
-  "githubUrl": "https://github.com/amplify-education/serverless-domain-manager",
-  "status": "active"
-}, {
-  "name": "serverless-log-forwarding",
-  "description": "Serverless plugin for forwarding CloudWatch logs to another Lambda function.",
-  "githubUrl": "https://github.com/amplify-education/serverless-log-forwarding",
-  "status": "active"
-}, {
-  "name": "serverless-event-body-option",
-  "description": "Serverless plugin that provides the extra CLI option for the invoke command to support passing the HTTP body data.",
-  "githubUrl": "https://github.com/jubel-han/serverless-event-body-option",
-  "status": "active"
-}, {
-  "name": "serverless-plugin-external-sns-events",
-  "description": "Add ability for functions to use existing or external SNS topics as an event source",
-  "githubUrl": "https://github.com/silvermine/serverless-plugin-external-sns-events",
-  "status": "active"
-}, {
-  "name": "serverless-plugin-write-env-vars",
-  "description": "Write environment variables out to a file that is compatible with dotenv",
-  "githubUrl": "https://github.com/silvermine/serverless-plugin-write-env-vars",
-  "status": "active"
-}, {
-  "name": "serverless-alexa-plugin",
-  "description": "Serverless plugin to support Alexa Lambda events",
-  "githubUrl": "https://github.com/rajington/serverless-alexa-plugin",
-  "status": "active"
-}, {
-  "name": "serverless-build-plugin",
-  "description": "A Node.js focused build plugin for serverless.",
-  "githubUrl": "https://github.com/nfour/serverless-build-plugin",
-  "status": "active"
-}, {
-  "name": "serverless-resources-env",
-  "description": "After Deploy, this plugin fetches cloudformation resource identifiers and sets them on AWS lambdas, and creates local .<state>-env file",
-  "githubUrl": "https://github.com/rurri/serverless-resources-env",
-  "status": "active"
-}, {
-  "name": "serverless-event-constant-inputs",
-  "description": "Allows you to add constant inputs to events in Serverless 1.0. For more info see [constant values in Cloudwatch](https://aws.amazon.com/blogs/compute/simply-serverless-use-constant-values-in-cloudwatch-event-triggered-lambda-functions/)",
-  "githubUrl": "https://github.com/dittto/serverless-event-constant-inputs",
-  "status": "active"
-}, {
-  "name": "serverless-kms-secrets",
-  "description": "Allows to easily encrypt and decrypt secrets using KMS from the serverless CLI",
-  "githubUrl": "https://github.com/SC5/serverless-kms-secrets",
-  "status": "active"
-}, {
-  "name": "serverless-openapi-integration-helper",
-  "description": "Provides functionality to merge stage-dependent x-amazon-apigateway integrations into openApiSpecification files ",
-  "githubUrl": "https://github.com/yndlingsfar/serverless-openapi-integration-helper",
-  "status": "active"
-}, {
-  "name": "serverless-plugin-stack-outputs",
-  "description": "Displays stack outputs for your serverless stacks when `sls info` is ran",
-  "githubUrl": "https://github.com/svdgraaf/serverless-plugin-stack-outputs",
-  "status": "active"
-}, {
-  "name": "serverless-plugin-stage-variables",
-  "description": "Add stage variables for Serverless 1.x to ApiGateway, so you can use variables in your Lambda's",
-  "githubUrl": "https://github.com/svdgraaf/serverless-plugin-stage-variables",
-  "status": "active"
-}, {
-  "name": "serverless-plugin-cloudwatch-sumologic",
-  "description": "Plugin which auto-subscribes a log delivery lambda function to lambda log groups created by serverless",
-  "githubUrl": "https://github.com/ACloudGuru/serverless-plugin-cloudwatch-sumologic",
-  "status": "active"
-}, {
-  "name": "serverless-plugin-aws-alerts",
-  "description": "A Serverless plugin to easily add CloudWatch alarms to functions",
-  "githubUrl": "https://github.com/ACloudGuru/serverless-plugin-aws-alerts",
-  "status": "active"
-}, {
-  "name": "serverless-plugin-package-dotenv-file",
-  "description": "A Serverless plugin to copy a .env file into the serverless package",
-  "githubUrl": "https://github.com/ACloudGuru/serverless-plugin-package-dotenv-file",
-  "status": "active"
-}, {
-  "name": "serverless-command-line-event-args",
-  "description": "This module is Serverless Framework plugin. Event JSON passes to your Lambda function in commandline.",
-  "githubUrl": "https://github.com/horike37/serverless-command-line-event-args",
-  "status": "active"
-}, {
-  "name": "serverless-dynamodb-client",
-  "description": "This Serverless 0.5.x plugin help you to call AWS Dynamodb SDK without switching between different dynamodb instances, whether you work with Dynamodb local or online in AWS.",
-  "githubUrl": "https://github.com/99xt/serverless-dynamodb-client",
-  "status": "active"
-}, {
-  "name": "serverless-dynamodb-local",
-  "description": "Serverless Dynamodb Local Plugin - Allows to run dynamodb locally for serverless",
-  "githubUrl": "https://github.com/99xt/serverless-dynamodb-local",
-  "status": "active"
-}, {
-  "name": "serverless-dynamodb-fixtures",
-  "description": "Serverless Dynamodb Fixtures - Allows to load data on DynamoDB tables",
-  "githubUrl": "https://github.com/chechu/serverless-dynamodb-fixtures",
-  "status": "active"
-}, {
-  "name": "serverless-dynamo-stream-plugin",
-  "description": "Creates and connects DynamoDB streams for pre-existing tables with AWS Lambdas using Serverless.",
-  "githubUrl": "https://github.com/commandeer/open/tree/development/serverless-dynamo-stream-plugin",
-  "status": "active"
-}, {
-  "name": "dynamo-data-transform",
-  "description": "Dynamo Data Transform is an easy to use data transformation tool for DynamoDB.",
-  "githubUrl": "https://github.com/jitsecurity/dynamo-data-transform",
-  "status": "active"
-}, {
-  "name": "serverless-offline",
-  "description": "Emulate AWS λ and API Gateway locally when developing your Serverless project",
-  "githubUrl": "https://github.com/dherault/serverless-offline",
-  "status": "active"
-}, {
-  "name": "serverless-offline-local-authorizers-plugin",
-  "description": "Serverless plugin for adding and mocking local authorizers when developing locally with serverless-offline.",
-  "githubUrl": "https://github.com/nlang/serverless-offline-local-authorizers-plugin",
-  "status": "active"
-}, {
-  "name": "serverless-offline-ssm",
-  "description": "Read SSM parameters from a .env file instead of AWS",
-  "githubUrl": "https://github.com/janders223/serverless-offline-ssm",
-  "status": "active"
-}, {
-  "name": "serverless-offline-direct-lambda",
-  "description": "Allow offline direct lambda-to-lambda interactions by exposing lambdas with no API Gateway event via HTTP.",
-  "githubUrl": "https://github.com/civicteam/serverless-offline-direct-lambda",
-  "status": "active"
-}, {
-  "name": "serverless-offline-ses-v2",
-  "description": "Serverless plugin to run a local version of Amazon Simple Email Service (SES) supporting the V1 and V2 SendEmail and SendRawEmail APIs",
-  "githubUrl": "https://github.com/domdomegg/serverless-offline-ses-v2",
-  "status": "active"
-}, {
-  "name": "serverless-offline-edge-lambda",
-  "description": "A plugin for the Serverless Framework that simulates the behavior of AWS CloudFront Edge Lambdas while developing offline",
-  "githubUrl": "https://github.com/evolv-ai/serverless-offline-edge-lambda",
-  "status": "active"
-}, {
-  "name": "serverless-plugin-simulate",
-  "description": "Simulate AWS Lambda and API Gateway locally using Docker",
-  "githubUrl": "https://github.com/gertjvr/serverless-plugin-simulate",
-  "status": "active"
-}, {
-  "name": "serverless-plugin-optimize",
-  "description": "Bundle with Browserify, transpile with Babel to ES5 and minify with Uglify your Serverless functions.",
-  "githubUrl": "https://github.com/FidelLimited/serverless-plugin-optimize",
-  "status": "active"
-}, {
-  "name": "serverless-plugin-select",
-  "description": "Select which functions are to be deployed based on region and stage.",
-  "githubUrl": "https://github.com/FidelLimited/serverless-plugin-select",
-  "status": "active"
-}, {
-  "name": "serverless-plugin-warmup",
-  "description": "Keep your lambdas warm during Winter.",
-  "githubUrl": "https://github.com/juanjoDiaz/serverless-plugin-warmup",
-  "status": "active"
-}, {
-  "name": "serverless-plugin-aws-contributor-insights",
-  "description": "Support of AWS CloudWatch Contributor Insights",
-  "githubUrl": "https://github.com/kangcifong/serverless-plugin-aws-contributor-insights",
-  "status": "active"
-}, {
-  "name": "serverless-plugin-browserify",
-  "description": "Speed up your node based lambda's",
-  "githubUrl": "https://github.com/doapp-ryanp/serverless-plugin-browserify",
-  "status": "inactive"
-}, {
-  "name": "serverless-plugin-datadog",
-  "description": "Monitoring, tracing, and real-time metrics for your Lambda functions",
-  "githubUrl": "https://github.com/DataDog/serverless-plugin-datadog",
-  "status": "active"
-}, {
-  "name": "serverless-plugin-diff",
-  "description": "Compares your local AWS CloudFormation templates against deployed ones.",
-  "githubUrl": "https://github.com/nicka/serverless-plugin-diff",
-  "status": "active"
-}, {
-  "name": "serverless-run-function-plugin",
-  "description": "Run serverless function locally",
-  "githubUrl": "https://github.com/lithin/serverless-run-function-plugin",
-  "status": "active"
-}, {
-  "name": "serverless-scriptable-plugin",
-  "description": "Customize Serverless behavior without writing a plugin.",
-  "githubUrl": "https://github.com/weixu365/serverless-scriptable-plugin",
-  "status": "active"
-}, {
-  "name": "serverless-subscription-filter",
-  "description": "Serverless plugin to register subscription filter for Lambda logs. Register and pipe the logs of one lambda to another to process.",
-  "githubUrl": "https://github.com/blackevil245/serverless-subscription-filter",
-  "status": "active"
-}, {
-  "name": "serverless-webpack",
-  "description": "Serverless plugin to bundle your lambdas with Webpack",
-  "githubUrl": "https://github.com/serverless-heaven/serverless-webpack",
-  "status": "active"
-}, {
-  "name": "serverless-esbuild",
-  "description": "Serverless plugin to bundle JavaScript and TypeScript lambdas with esbuild - an extremely fast bundler and minifier",
-  "githubUrl": "https://github.com/floydspace/serverless-esbuild",
-  "status": "active"
-}, {
-  "name": "serverless-wsgi",
-  "description": "Serverless plugin to deploy WSGI applications (Flask/Django/Pyramid etc.) and bundle Python packages",
-  "githubUrl": "https://github.com/logandk/serverless-wsgi",
-  "status": "active"
-}, {
-  "name": "serverless-crypt",
-  "description": "Securing the secrets on Serverless Framework by AWS KMS encryption.",
-  "githubUrl": "https://github.com/marcy-terui/serverless-crypt",
-  "status": "active"
-}, {
-  "name": "serverless-plugin-multiple-responses",
-  "description": "Enable multiple content-types for Response template ",
-  "githubUrl": "https://github.com/silvermine/serverless-plugin-multiple-responses",
-  "status": "active"
-}, {
-  "name": "serverless-plugin-dot-template",
-  "description": "Generates output files based on Serverless variables and doT templates",
-  "githubUrl": "https://github.com/kandsten/serverless-plugin-dot-template",
-  "status": "active"
-}, {
-  "name": "serverless-plugin-include-dependencies",
-  "description": "This is a Serverless plugin that should make your deployed functions smaller.",
-  "githubUrl": "https://github.com/dougmoscrop/serverless-plugin-include-dependencies",
-  "status": "active"
-}, {
-  "name": "serverless-mocha-plugin",
-  "description": "A Serverless Plugin for the Serverless Framework which adds support for test-driven development using Mocha",
-  "githubUrl": "https://github.com/SC5/serverless-mocha-plugin",
-  "status": "active"
-}, {
-  "name": "serverless-modular",
-  "description": "Helps you deploy and manage multiple features with single root serverless file",
-  "githubUrl": "https://github.com/aa2kb/serverless-modular",
-  "status": "active"
-}, {
-  "name": "serverless-jest-plugin",
-  "description": "A Serverless Plugin for the Serverless Framework which adds support for test-driven development using Jest",
-  "githubUrl": "https://github.com/SC5/serverless-jest-plugin",
-  "status": "active"
-}, {
-  "name": "serverless-plugin-cfauthorizer",
-  "description": "This plugin allows you to define your own API Gateway Authorizers as the Serverless CloudFormation resources and apply them to HTTP endpoints.",
-  "githubUrl": "https://github.com/SC5/serverless-plugin-cfauthorizer",
-  "status": "active"
-}, {
-  "name": "serverless-cloudformation-changesets",
-  "description": "Natively deploy to CloudFormation via Change sets, instead of directly. Allowing you to queue changes, and safely require escalated roles for final deployment.",
-  "githubUrl": "https://github.com/trek10inc/serverless-cloudformation-changesets",
-  "status": "active"
-}, {
-  "name": "raml-serverless",
-  "description": "Serverless plugin to work with RAML API spec documents",
-  "githubUrl": "https://github.com/andrewcurioso/raml-serverless",
-  "status": "active"
-}, {
-  "name": "serverless-python-requirements",
-  "description": "Serverless plugin to bundle Python packages",
-  "githubUrl": "https://github.com/UnitedIncome/serverless-python-requirements",
-  "status": "active"
-}, {
-  "name": "serverless-pydeps",
-  "description": "Serverless plugin to quickly automate Python dependencies",
-  "githubUrl": "https://github.com/CloudSnorkel/serverless-pydeps",
-  "status": "active"
-}, {
-  "name": "serverless-ruby-layer",
-  "description": "A Serverless Plugin to auto deploy gems to AWS Layer using Gemfile",
-  "githubUrl": "https://github.com/navarasu/serverless-ruby-layer",
-  "status": "active"
-}, {
-  "name": "serverless-multi-dotnet",
-  "description": "A serverless plugin to pack C# lambdas functions that are spread to multiple CS projects.",
-  "githubUrl": "https://github.com/tsibelman/serverless-multi-dotnet",
-  "status": "active"
+    "name": "serverless-plugin-utils",
+    "description": "A collection of serverless framework utilities",
+    "githubUrl": "https://github.com/icarus-sullivan/serverless-plugin-utils",
+    "status": "active"
+}, {
+    "name": "serverless-layers",
+    "description": "How to reduce drastically lambda size",
+    "githubUrl": "https://github.com/agutoli/serverless-layers",
+    "status": "active"
+}, {
+    "name": "mfa-serverless-plugin",
+    "description": "A simple plugin for deployment accounts with MFA",
+    "githubUrl": "https://github.com/alikian/mfa-serverless-plugin",
+    "status": "active"
+}, {
+    "name": "serverless-ini-env",
+    "description": "Nice Serverless plugin to setup environment variables with ini file",
+    "githubUrl": "https://github.com/agutoli/serverless-ini-env",
+    "status": "active"
+}, {
+    "name": "serverless-websockets-plugin",
+    "description": "Websocket support for Serverless Framework on AWS",
+    "githubUrl": "https://github.com/serverless/serverless-websockets-plugin",
+    "status": "active"
+}, {
+    "name": "serverless-resource-policy",
+    "description": "Creates a whitelist of IP or CIDR addresses using serverless resource policies",
+    "githubUrl": "https://github.com/HubSpotWebTeam/serverless-resource-policy",
+    "status": "active"
+}, {
+    "name": "serverless-plugin-vault-v2",
+    "description": "Simplify integration between serverless and vault to storage environments variables",
+    "githubUrl": "https://github.com/eliasjcjunior/serverless-plugin-vault-v2",
+    "status": "active"
+}, {
+    "name": "serverless-plugin-powertools",
+    "description": "Serverless plugin adding several variable tools, resolvers, and commands",
+    "githubUrl": "https://github.com/whardier/serverless-plugin-powertools",
+    "status": "active"
+}, {
+    "name": "serverless-justauthenticateme-plugin",
+    "description": "Use JustAuthenticateMe to easily authenticate users before hitting your lambdas",
+    "githubUrl": "https://github.com/CoalesceSoftware/serverless-justauthenticateme-plugin",
+    "status": "active"
+}, {
+    "name": "serverless-openapi-plugin",
+    "description": "Serverless plugin to generate serverless API architecture from OpenAPI definition.",
+    "githubUrl": "https://github.com/jaumard/serverless-openapi-plugin",
+    "status": "active"
+}, {
+    "name": "serverless-dotenv-plugin",
+    "description": "Preload environment variables from `.env` into serverless.",
+    "githubUrl": "https://github.com/infrontlabs/serverless-dotenv-plugin",
+    "status": "active"
+}, {
+    "name": "serverless-disable-request-validators",
+    "description": "Serverless v2/v3 plugin to disable API Gateway request validators.",
+    "githubUrl": "https://github.com/jweyrich/serverless-disable-request-validators",
+    "status": "active"
+}, {
+    "name": "serverless-default-aws-resource-attributes",
+    "description": "Set default attributes a given CloudFormation resource should have based on type.",
+    "githubUrl": "https://github.com/neverendingqs/serverless-default-aws-resource-attributes",
+    "status": "active"
+}, {
+    "name": "serverless-stack-policy-by-resource-type",
+    "description": "Serverless Framework plugin for automatically populating CloudFormation stack policy statements by resource type.",
+    "githubUrl": "https://github.com/neverendingqs/serverless-stack-policy-by-resource-type",
+    "status": "active"
+}, {
+    "name": "serverless-print-resolved-plugin",
+    "description": "Generate a copy of serverless.yml with all variables resolved.",
+    "githubUrl": "https://github.com/neverendingqs/serverless-print-resolved-plugin",
+    "status": "active"
+}, {
+    "name": "serverless-discovery-plugin",
+    "description": "A serverless plugin to register AWS micro-service endpoints with a discovery service at serverless deploy or serverless remove time.",
+    "githubUrl": "https://github.com/aregier/serverless-discovery-plugin",
+    "status": "active"
+}, {
+    "name": "fullstack-serverless",
+    "description": "A Serverless plugin to create an AWS CloudFront distribution that serves static web content from S3 and routes API traffic to API Gateway.",
+    "githubUrl": "https://github.com/MadSkills-io/fullstack-serverless",
+    "status": "active"
+}, {
+    "name": "serverless-finch",
+    "description": "A Serverless plugin to deploy static website assets to AWS S3.",
+    "githubUrl": "https://github.com/fernando-mc/serverless-finch",
+    "status": "active"
+}, {
+    "name": "serverless-appsync-plugin",
+    "description": "Serverless Plugin to deploy AppSync GraphQL API",
+    "githubUrl": "https://github.com/sid88in/serverless-appsync-plugin",
+    "status": "active"
+}, {
+    "name": "serverless-appsync-simulator",
+    "description": "Offline support for serverless-appsync-plugin",
+    "githubUrl": "https://github.com/bboure/serverless-appsync-simulator",
+    "status": "active"
+}, {
+    "name": "serverless-remote-json-envs",
+    "description": "Allows to use plain JSON files in remote locations being parsed as environment variables in lambda",
+    "githubUrl": "https://github.com/juancarestre/serverless-remote-json-envs",
+    "status": "active"
+}, {
+    "name": "serverless-plugin-tag-cloud-watch-logs",
+    "description": "Small serverless plugin providing a way to add tags to CloudWatch resources",
+    "githubUrl": "https://github.com/pretty-fun-therapy/serverless-plugin-tag-cloud-watch-logs",
+    "status": "active"
+}, {
+    "name": "serverless-appsync-offline",
+    "description": "Serverless Plugin to run AWS AppSync GraphQL API localy with dynamoDB and lambda resolvers",
+    "githubUrl": "https://github.com/aheissenberger/serverless-appsync-offline",
+    "status": "active"
+}, {
+    "name": "aws-amplify-serverless-plugin",
+    "description": "Generate client-side configuration files for the AWS Amplify library based on your deployed Serverless backend",
+    "githubUrl": "https://github.com/awslabs/aws-amplify-serverless-plugin",
+    "status": "active"
+}, {
+    "name": "serverless-amplify-auth",
+    "description": "Update Policy for Amplify's Auth Role and Unauth Role",
+    "githubUrl": "https://github.com/nikaera/serverless-amplify-auth",
+    "status": "active"
+}, {
+    "name": "serverless-cloudformation-parameter-setter",
+    "description": "Set CloudFormation parameters when deploying.",
+    "githubUrl": "https://github.com/trek10inc/serverless-cloudformation-parameter-setter",
+    "status": "active"
+}, {
+    "name": "serverless-alexa-skills",
+    "description": "Manage your Alexa Skills with Serverless Framework.",
+    "githubUrl": "https://github.com/marcy-terui/serverless-alexa-skills",
+    "status": "active"
+}, {
+    "name": "serverless-plugin-chrome",
+    "description": "Plugin which bundles and ensures that Headless Chrome/Chromium is running when your AWS Lambda function handler is invoked.",
+    "githubUrl": "https://github.com/adieuadieu/serverless-chrome/tree/master/packages/serverless-plugin",
+    "status": "active"
+}, {
+    "name": "serverless-ssm-fetch",
+    "description": "Sets \"AWS Systems Manager Parameter Store (SSM)\" parameters into functions' environment variables.",
+    "githubUrl": "https://github.com/gozup/serverless-ssm-fetch",
+    "status": "active"
+}, {
+    "name": "serverless-custom-packaging-plugin",
+    "description": "Plugin to package your sourcecode using a custom target path inside the zip.",
+    "githubUrl": "https://github.com/hypoport/serverless-custom-packaging-plugin",
+    "status": "active"
+}, {
+    "name": "kumologica-serverless-plugin",
+    "description": "Plugin to package and deploy Kumologica flow into AWS",
+    "githubUrl": "https://github.com/KumologicaHQ/kumologica-serverless-plugin"
+}, {
+    "name": "serverless-apigw-binary",
+    "description": "Plugin to enable binary support in AWS API Gateway.",
+    "githubUrl": "https://github.com/maciejtreder/serverless-apigw-binary",
+    "status": "active"
+}, {
+    "name": "serverless-certificate-creator",
+    "description": "This serverless plugin creates certificates that you need for your custom domains in API Gateway.",
+    "githubUrl": "https://github.com/schwamster/serverless-certificate-creator",
+    "status": "active"
+}, {
+    "name": "serverless-apigator",
+    "description": "This serverless plugin enables you to write AWS lambda with typescript using Microgamma",
+    "githubUrl": "https://github.com/microgamma/microgamma",
+    "status": "active"
+}, {
+    "name": "serverless-plugin-1password",
+    "description": "Serverless interface to 1Password data via the 1Password CLI",
+    "githubUrl": "https://github.com/kandsten/serverless-plugin-1password",
+    "status": "active"
+}, {
+    "name": "serverless-log-filter-subscription",
+    "description": "This serverless plugin creates log filter subscription for all lambda functions configured in your projects serverless.yml",
+    "githubUrl": "https://github.com/schwamster/serverless-log-filter-subscription",
+    "status": "active"
+}, {
+    "name": "serverless-domain-manager",
+    "description": "Serverless plugin for managing custom domains with API Gateways.",
+    "githubUrl": "https://github.com/amplify-education/serverless-domain-manager",
+    "status": "active"
+}, {
+    "name": "serverless-log-forwarding",
+    "description": "Serverless plugin for forwarding CloudWatch logs to another Lambda function.",
+    "githubUrl": "https://github.com/amplify-education/serverless-log-forwarding",
+    "status": "active"
+}, {
+    "name": "serverless-event-body-option",
+    "description": "Serverless plugin that provides the extra CLI option for the invoke command to support passing the HTTP body data.",
+    "githubUrl": "https://github.com/jubel-han/serverless-event-body-option",
+    "status": "active"
+}, {
+    "name": "serverless-plugin-external-sns-events",
+    "description": "Add ability for functions to use existing or external SNS topics as an event source",
+    "githubUrl": "https://github.com/silvermine/serverless-plugin-external-sns-events",
+    "status": "active"
+}, {
+    "name": "serverless-plugin-write-env-vars",
+    "description": "Write environment variables out to a file that is compatible with dotenv",
+    "githubUrl": "https://github.com/silvermine/serverless-plugin-write-env-vars",
+    "status": "active"
+}, {
+    "name": "serverless-alexa-plugin",
+    "description": "Serverless plugin to support Alexa Lambda events",
+    "githubUrl": "https://github.com/rajington/serverless-alexa-plugin",
+    "status": "active"
+}, {
+    "name": "serverless-build-plugin",
+    "description": "A Node.js focused build plugin for serverless.",
+    "githubUrl": "https://github.com/nfour/serverless-build-plugin",
+    "status": "active"
+}, {
+    "name": "serverless-resources-env",
+    "description": "After Deploy, this plugin fetches cloudformation resource identifiers and sets them on AWS lambdas, and creates local .<state>-env file",
+    "githubUrl": "https://github.com/rurri/serverless-resources-env",
+    "status": "active"
+}, {
+    "name": "serverless-event-constant-inputs",
+    "description": "Allows you to add constant inputs to events in Serverless 1.0. For more info see [constant values in Cloudwatch](https://aws.amazon.com/blogs/compute/simply-serverless-use-constant-values-in-cloudwatch-event-triggered-lambda-functions/)",
+    "githubUrl": "https://github.com/dittto/serverless-event-constant-inputs",
+    "status": "active"
+}, {
+    "name": "serverless-kms-secrets",
+    "description": "Allows to easily encrypt and decrypt secrets using KMS from the serverless CLI",
+    "githubUrl": "https://github.com/SC5/serverless-kms-secrets",
+    "status": "active"
+}, {
+    "name": "serverless-openapi-integration-helper",
+    "description": "Provides functionality to merge stage-dependent x-amazon-apigateway integrations into openApiSpecification files ",
+    "githubUrl": "https://github.com/yndlingsfar/serverless-openapi-integration-helper",
+    "status": "active"
+}, {
+    "name": "serverless-plugin-stack-outputs",
+    "description": "Displays stack outputs for your serverless stacks when `sls info` is ran",
+    "githubUrl": "https://github.com/svdgraaf/serverless-plugin-stack-outputs",
+    "status": "active"
+}, {
+    "name": "serverless-plugin-stage-variables",
+    "description": "Add stage variables for Serverless 1.x to ApiGateway, so you can use variables in your Lambda's",
+    "githubUrl": "https://github.com/svdgraaf/serverless-plugin-stage-variables",
+    "status": "active"
+}, {
+    "name": "serverless-plugin-cloudwatch-sumologic",
+    "description": "Plugin which auto-subscribes a log delivery lambda function to lambda log groups created by serverless",
+    "githubUrl": "https://github.com/ACloudGuru/serverless-plugin-cloudwatch-sumologic",
+    "status": "active"
+}, {
+    "name": "serverless-plugin-aws-alerts",
+    "description": "A Serverless plugin to easily add CloudWatch alarms to functions",
+    "githubUrl": "https://github.com/ACloudGuru/serverless-plugin-aws-alerts",
+    "status": "active"
+}, {
+    "name": "serverless-plugin-package-dotenv-file",
+    "description": "A Serverless plugin to copy a .env file into the serverless package",
+    "githubUrl": "https://github.com/ACloudGuru/serverless-plugin-package-dotenv-file",
+    "status": "active"
+}, {
+    "name": "serverless-command-line-event-args",
+    "description": "This module is Serverless Framework plugin. Event JSON passes to your Lambda function in commandline.",
+    "githubUrl": "https://github.com/horike37/serverless-command-line-event-args",
+    "status": "active"
+}, {
+    "name": "serverless-dynamodb-client",
+    "description": "This Serverless 0.5.x plugin help you to call AWS Dynamodb SDK without switching between different dynamodb instances, whether you work with Dynamodb local or online in AWS.",
+    "githubUrl": "https://github.com/99xt/serverless-dynamodb-client",
+    "status": "active"
+}, {
+    "name": "serverless-dynamodb-local",
+    "description": "Serverless Dynamodb Local Plugin - Allows to run dynamodb locally for serverless",
+    "githubUrl": "https://github.com/99xt/serverless-dynamodb-local",
+    "status": "active"
+}, {
+    "name": "serverless-dynamodb-fixtures",
+    "description": "Serverless Dynamodb Fixtures - Allows to load data on DynamoDB tables",
+    "githubUrl": "https://github.com/chechu/serverless-dynamodb-fixtures",
+    "status": "active"
+}, {
+    "name": "serverless-dynamo-stream-plugin",
+    "description": "Creates and connects DynamoDB streams for pre-existing tables with AWS Lambdas using Serverless.",
+    "githubUrl": "https://github.com/commandeer/open/tree/development/serverless-dynamo-stream-plugin",
+    "status": "active"
+}, {
+    "name": "dynamo-data-transform",
+    "description": "Dynamo Data Transform is an easy to use data transformation tool for DynamoDB.",
+    "githubUrl": "https://github.com/jitsecurity/dynamo-data-transform",
+    "status": "active"
+}, {
+    "name": "serverless-offline",
+    "description": "Emulate AWS λ and API Gateway locally when developing your Serverless project",
+    "githubUrl": "https://github.com/dherault/serverless-offline",
+    "status": "active"
+}, {
+    "name": "serverless-offline-local-authorizers-plugin",
+    "description": "Serverless plugin for adding and mocking local authorizers when developing locally with serverless-offline.",
+    "githubUrl": "https://github.com/nlang/serverless-offline-local-authorizers-plugin",
+    "status": "active"
+}, {
+    "name": "serverless-offline-ssm",
+    "description": "Read SSM parameters from a .env file instead of AWS",
+    "githubUrl": "https://github.com/janders223/serverless-offline-ssm",
+    "status": "active"
+}, {
+    "name": "serverless-offline-direct-lambda",
+    "description": "Allow offline direct lambda-to-lambda interactions by exposing lambdas with no API Gateway event via HTTP.",
+    "githubUrl": "https://github.com/civicteam/serverless-offline-direct-lambda",
+    "status": "active"
+}, {
+    "name": "serverless-offline-ses-v2",
+    "description": "Serverless plugin to run a local version of Amazon Simple Email Service (SES) supporting the V1 and V2 SendEmail and SendRawEmail APIs",
+    "githubUrl": "https://github.com/domdomegg/serverless-offline-ses-v2",
+    "status": "active"
+}, {
+	"name": "serverless-offline-edge-lambda",
+    "description": "A plugin for the Serverless Framework that simulates the behavior of AWS CloudFront Edge Lambdas while developing offline",
+    "githubUrl": "https://github.com/evolv-ai/serverless-offline-edge-lambda",
+    "status": "active"
+}, {
+    "name": "serverless-plugin-simulate",
+    "description": "Simulate AWS Lambda and API Gateway locally using Docker",
+    "githubUrl": "https://github.com/gertjvr/serverless-plugin-simulate",
+    "status": "active"
+}, {
+    "name": "serverless-plugin-optimize",
+    "description": "Bundle with Browserify, transpile with Babel to ES5 and minify with Uglify your Serverless functions.",
+    "githubUrl": "https://github.com/FidelLimited/serverless-plugin-optimize",
+    "status": "active"
+}, {
+    "name": "serverless-plugin-select",
+    "description": "Select which functions are to be deployed based on region and stage.",
+    "githubUrl": "https://github.com/FidelLimited/serverless-plugin-select",
+    "status": "active"
+}, {
+    "name": "serverless-plugin-warmup",
+    "description": "Keep your lambdas warm during Winter.",
+    "githubUrl": "https://github.com/juanjoDiaz/serverless-plugin-warmup",
+    "status": "active"
+}, {
+    "name": "serverless-plugin-aws-contributor-insights",
+    "description": "Support of AWS CloudWatch Contributor Insights",
+    "githubUrl": "https://github.com/kangcifong/serverless-plugin-aws-contributor-insights",
+    "status": "active"
+}, {
+    "name": "serverless-plugin-browserify",
+    "description": "Speed up your node based lambda's",
+    "githubUrl": "https://github.com/doapp-ryanp/serverless-plugin-browserify",
+    "status": "inactive"
+}, {
+    "name": "serverless-plugin-datadog",
+    "description": "Monitoring, tracing, and real-time metrics for your Lambda functions",
+    "githubUrl": "https://github.com/DataDog/serverless-plugin-datadog",
+    "status": "active"
+}, {
+    "name": "serverless-plugin-diff",
+    "description": "Compares your local AWS CloudFormation templates against deployed ones.",
+    "githubUrl": "https://github.com/nicka/serverless-plugin-diff",
+    "status": "active"
+}, {
+    "name": "serverless-run-function-plugin",
+    "description": "Run serverless function locally",
+    "githubUrl": "https://github.com/lithin/serverless-run-function-plugin",
+    "status": "active"
+}, {
+    "name": "serverless-scriptable-plugin",
+    "description": "Customize Serverless behavior without writing a plugin.",
+    "githubUrl": "https://github.com/weixu365/serverless-scriptable-plugin",
+    "status": "active"
+}, {
+    "name": "serverless-subscription-filter",
+    "description": "Serverless plugin to register subscription filter for Lambda logs. Register and pipe the logs of one lambda to another to process.",
+    "githubUrl": "https://github.com/blackevil245/serverless-subscription-filter",
+    "status": "active"
+}, {
+    "name": "serverless-webpack",
+    "description": "Serverless plugin to bundle your lambdas with Webpack",
+    "githubUrl": "https://github.com/serverless-heaven/serverless-webpack",
+    "status": "active"
+}, {
+    "name": "serverless-esbuild",
+    "description": "Serverless plugin to bundle JavaScript and TypeScript lambdas with esbuild - an extremely fast bundler and minifier",
+    "githubUrl": "https://github.com/floydspace/serverless-esbuild",
+    "status": "active"
+}, {
+    "name": "serverless-wsgi",
+    "description": "Serverless plugin to deploy WSGI applications (Flask/Django/Pyramid etc.) and bundle Python packages",
+    "githubUrl": "https://github.com/logandk/serverless-wsgi",
+    "status": "active"
+}, {
+    "name": "serverless-crypt",
+    "description": "Securing the secrets on Serverless Framework by AWS KMS encryption.",
+    "githubUrl": "https://github.com/marcy-terui/serverless-crypt",
+    "status": "active"
+}, {
+    "name": "serverless-plugin-multiple-responses",
+    "description": "Enable multiple content-types for Response template ",
+    "githubUrl": "https://github.com/silvermine/serverless-plugin-multiple-responses",
+    "status": "active"
+}, {
+    "name": "serverless-plugin-dot-template",
+    "description": "Generates output files based on Serverless variables and doT templates",
+    "githubUrl": "https://github.com/kandsten/serverless-plugin-dot-template",
+    "status": "active"
+}, {
+    "name": "serverless-plugin-include-dependencies",
+    "description": "This is a Serverless plugin that should make your deployed functions smaller.",
+    "githubUrl": "https://github.com/dougmoscrop/serverless-plugin-include-dependencies",
+    "status": "active"
+}, {
+    "name": "serverless-mocha-plugin",
+    "description": "A Serverless Plugin for the Serverless Framework which adds support for test-driven development using Mocha",
+    "githubUrl": "https://github.com/SC5/serverless-mocha-plugin",
+    "status": "active"
+}, {
+    "name": "serverless-modular",
+    "description": "Helps you deploy and manage multiple features with single root serverless file",
+    "githubUrl": "https://github.com/aa2kb/serverless-modular",
+    "status": "active"
+}, {
+    "name": "serverless-jest-plugin",
+    "description": "A Serverless Plugin for the Serverless Framework which adds support for test-driven development using Jest",
+    "githubUrl": "https://github.com/SC5/serverless-jest-plugin",
+    "status": "active"
+}, {
+    "name": "serverless-plugin-cfauthorizer",
+    "description": "This plugin allows you to define your own API Gateway Authorizers as the Serverless CloudFormation resources and apply them to HTTP endpoints.",
+    "githubUrl": "https://github.com/SC5/serverless-plugin-cfauthorizer",
+    "status": "active"
+}, {
+    "name": "serverless-cloudformation-changesets",
+    "description": "Natively deploy to CloudFormation via Change sets, instead of directly. Allowing you to queue changes, and safely require escalated roles for final deployment.",
+    "githubUrl": "https://github.com/trek10inc/serverless-cloudformation-changesets",
+    "status": "active"
+}, {
+    "name": "raml-serverless",
+    "description": "Serverless plugin to work with RAML API spec documents",
+    "githubUrl": "https://github.com/andrewcurioso/raml-serverless",
+    "status": "active"
+}, {
+    "name": "serverless-python-requirements",
+    "description": "Serverless plugin to bundle Python packages",
+    "githubUrl": "https://github.com/UnitedIncome/serverless-python-requirements",
+    "status": "active"
+}, {
+    "name": "serverless-pydeps",
+    "description": "Serverless plugin to quickly automate Python dependencies",
+    "githubUrl": "https://github.com/CloudSnorkel/serverless-pydeps",
+    "status": "active"
+}, {
+    "name": "serverless-ruby-layer",
+    "description": "A Serverless Plugin to auto deploy gems to AWS Layer using Gemfile",
+    "githubUrl": "https://github.com/navarasu/serverless-ruby-layer",
+    "status": "active"
+}, {
+    "name": "serverless-multi-dotnet",
+    "description": "A serverless plugin to pack C# lambdas functions that are spread to multiple CS projects.",
+    "githubUrl": "https://github.com/tsibelman/serverless-multi-dotnet",
+    "status": "active"
 },{
-  "name": "serverless-dotnet",
-  "description": "A serverless plugin to run 'dotnet' commands as part of the deploy process",
-  "githubUrl": "https://github.com/fruffin/serverless-dotnet",
-  "status": "active"
+    "name": "serverless-dotnet",
+    "description": "A serverless plugin to run 'dotnet' commands as part of the deploy process",
+    "githubUrl": "https://github.com/fruffin/serverless-dotnet",
+    "status": "active"
 }, {
-  "name": "serverless-enable-api-logs",
-  "description": "Enables Coudwatch logging for API Gateway events",
-  "githubUrl": "https://github.com/paulSambolin/serverless-enable-api-logs",
-  "status": "active"
+    "name": "serverless-enable-api-logs",
+    "description": "Enables Coudwatch logging for API Gateway events",
+    "githubUrl": "https://github.com/paulSambolin/serverless-enable-api-logs",
+    "status": "active"
 }, {
-  "name": "serverless-python-individually",
-  "description": "A serverless framework plugin to install multiple lambda functions written in python",
-  "githubUrl": "https://github.com/cfchou/serverless-python-individually",
-  "status": "active"
+    "name": "serverless-python-individually",
+    "description": "A serverless framework plugin to install multiple lambda functions written in python",
+    "githubUrl": "https://github.com/cfchou/serverless-python-individually",
+    "status": "active"
 }, {
-  "name": "serverless-plugin-subscription-filter",
-  "description": "A serverless plugin to register AWS CloudWatchLogs subscription filter",
-  "githubUrl": "https://github.com/tsub/serverless-plugin-subscription-filter",
-  "status": "active"
+    "name": "serverless-plugin-subscription-filter",
+    "description": "A serverless plugin to register AWS CloudWatchLogs subscription filter",
+    "githubUrl": "https://github.com/tsub/serverless-plugin-subscription-filter",
+    "status": "active"
 }, {
-  "name": "serverless-step-functions",
-  "description": "AWS Step Functions plugin for Serverless Framework",
-  "githubUrl": "https://github.com/serverless-operations/serverless-step-functions",
-  "status": "active"
+    "name": "serverless-step-functions",
+    "description": "AWS Step Functions plugin for Serverless Framework",
+    "githubUrl": "https://github.com/serverless-operations/serverless-step-functions",
+    "status": "active"
 }, {
-  "name": "serverless-lambda-layer-packager",
-  "description": "A Serverless plugin that allows you to maintain your normal project structure when developing Lambda Layers.",
-  "githubUrl": "https://github.com/bramhoven/serverless-lambda-layer-packager",
-  "status": "active"
+    "name": "serverless-lambda-layer-packager",
+    "description": "A Serverless plugin that allows you to maintain your normal project structure when developing Lambda Layers.",
+    "githubUrl": "https://github.com/bramhoven/serverless-lambda-layer-packager",
+    "status": "active"
 }, {
-  "name": "serverless-apigateway-service-proxy",
-  "description": "This Serverless Framewrok plugin supports the AWS service proxy integration feature of API Gateway.",
-  "githubUrl": "https://github.com/horike37/serverless-apigateway-service-proxy",
-  "status": "active"
+    "name": "serverless-apigateway-service-proxy",
+    "description": "This Serverless Framewrok plugin supports the AWS service proxy integration feature of API Gateway.",
+    "githubUrl": "https://github.com/horike37/serverless-apigateway-service-proxy",
+    "status": "active"
 }, {
-  "name": "serverless-package-customizer",
-  "description": "This allows you to customize packaging system of the Serverless Framework from a command line.",
-  "githubUrl": "https://github.com/horike37/serverless-package-customizer",
-  "status": "active"
+    "name": "serverless-package-customizer",
+    "description": "This allows you to customize packaging system of the Serverless Framework from a command line.",
+    "githubUrl": "https://github.com/horike37/serverless-package-customizer",
+    "status": "active"
 }, {
-  "name": "serverless-package-location-customizer",
-  "description": "A serverless plugin to allow custom S3Bucket and S3Key path when packaging Lambda Functions and Layers.",
-  "githubUrl": "https://github.com/cipri-p/serverless-package-location-customizer",
-  "status": "active"
+    "name": "serverless-package-location-customizer",
+    "description": "A serverless plugin to allow custom S3Bucket and S3Key path when packaging Lambda Functions and Layers.",
+    "githubUrl": "https://github.com/cipri-p/serverless-package-location-customizer",
+    "status": "active"
 }, {
-  "name": "serverless-plugin-scripts",
-  "description": "Add scripting capabilities to the Serverless Framework",
-  "githubUrl": "https://github.com/mvila/serverless-plugin-scripts",
-  "status": "active"
+    "name": "serverless-plugin-scripts",
+    "description": "Add scripting capabilities to the Serverless Framework",
+    "githubUrl": "https://github.com/mvila/serverless-plugin-scripts",
+    "status": "active"
 }, {
-  "name": "serverless-plugin-bind-deployment-id",
-  "description": "A Serverless plugin to bind the randomly generated deployment resource to your custom resources",
-  "githubUrl": "https://github.com/jacob-meacham/serverless-plugin-bind-deployment-id",
-  "status": "active"
+    "name": "serverless-plugin-bind-deployment-id",
+    "description": "A Serverless plugin to bind the randomly generated deployment resource to your custom resources",
+    "githubUrl": "https://github.com/jacob-meacham/serverless-plugin-bind-deployment-id",
+    "status": "active"
 }, {
-  "name": "serverless-plugin-git-variables",
-  "description": "A Serverless plugin to expose git variables (branch name, HEAD description, full commit hash) to your serverless services",
-  "githubUrl": "https://github.com/jacob-meacham/serverless-plugin-git-variables",
-  "status": "active"
+    "name": "serverless-plugin-git-variables",
+    "description": "A Serverless plugin to expose git variables (branch name, HEAD description, full commit hash) to your serverless services",
+    "githubUrl": "https://github.com/jacob-meacham/serverless-plugin-git-variables",
+    "status": "active"
 }, {
-  "name": "serverless-plugin-graphiql",
-  "description": "A Serverless plugin to run a local http server for graphiql and your graphql handler",
-  "githubUrl": "https://github.com/bencooling/serverless-plugin-graphiql",
-  "status": "active"
+    "name": "serverless-plugin-graphiql",
+    "description": "A Serverless plugin to run a local http server for graphiql and your graphql handler",
+    "githubUrl": "https://github.com/bencooling/serverless-plugin-graphiql",
+    "status": "active"
 }, {
-  "name": "serverless-coffeescript",
-  "description": "A Serverless plugin to compile your CoffeeScript into JavaScript at deployment",
-  "githubUrl": "https://github.com/duanefields/serverless-coffeescript",
-  "status": "active"
+    "name": "serverless-coffeescript",
+    "description": "A Serverless plugin to compile your CoffeeScript into JavaScript at deployment",
+    "githubUrl": "https://github.com/duanefields/serverless-coffeescript",
+    "status": "active"
 }, {
-  "name": "serverless-plugin-lambda-dead-letter",
-  "description": "A Serverless plugin that can configure a lambda with a dead letter queue or topic",
-  "githubUrl": "https://github.com/gmetzker/serverless-plugin-lambda-dead-letter",
-  "status": "active"
+    "name": "serverless-plugin-lambda-dead-letter",
+    "description": "A Serverless plugin that can configure a lambda with a dead letter queue or topic",
+    "githubUrl": "https://github.com/gmetzker/serverless-plugin-lambda-dead-letter",
+    "status": "active"
 }, {
-  "name": "serverless-plugin-encode-env-var-objects",
-  "description": "Serverless plugin to encode any environment variable objects.",
-  "githubUrl": "https://github.com/yonomi/serverless-plugin-encode-env-var-objects",
-  "status": "active"
+    "name": "serverless-plugin-encode-env-var-objects",
+    "description": "Serverless plugin to encode any environment variable objects.",
+    "githubUrl": "https://github.com/yonomi/serverless-plugin-encode-env-var-objects",
+    "status": "active"
 }, {
-  "name": "serverless-dir-config-plugin",
-  "description": "EXPERIMENTAL - Serverless plugin to load function and resource definitions from a directory.",
-  "githubUrl": "https://github.com/economysizegeek/serverless-dir-config-plugin",
-  "status": "active"
+    "name": "serverless-dir-config-plugin",
+    "description": "EXPERIMENTAL - Serverless plugin to load function and resource definitions from a directory.",
+    "githubUrl": "https://github.com/economysizegeek/serverless-dir-config-plugin",
+    "status": "active"
 }, {
-  "name": "serverless-cljs-plugin",
-  "description": "Enables Clojurescript as an implementation language for Lambda handlers",
-  "githubUrl": "https://github.com/nervous-systems/serverless-cljs-plugin",
-  "status": "active"
+    "name": "serverless-cljs-plugin",
+    "description": "Enables Clojurescript as an implementation language for Lambda handlers",
+    "githubUrl": "https://github.com/nervous-systems/serverless-cljs-plugin",
+    "status": "active"
 }, {
-  "name": "serverless-apigateway-log-retention",
-  "description": "Control the retention of your AWS ApiGateway access logs and execution logs.",
-  "githubUrl": "https://github.com/dvla/serverless-apigateway-log-retention",
-  "status": "active"
+    "name": "serverless-apigateway-log-retention",
+    "description": "Control the retention of your AWS ApiGateway access logs and execution logs.",
+    "githubUrl": "https://github.com/dvla/serverless-apigateway-log-retention",
+    "status": "active"
 }, {
-  "name": "serverless-prune-plugin",
-  "description": "Deletes old versions of functions from AWS, preserving recent and aliased versions",
-  "githubUrl": "https://github.com/claygregory/serverless-prune-plugin",
-  "status": "active"
+    "name": "serverless-prune-plugin",
+    "description": "Deletes old versions of functions from AWS, preserving recent and aliased versions",
+    "githubUrl": "https://github.com/claygregory/serverless-prune-plugin",
+    "status": "active"
 }, {
-  "name": "@unly/serverless-env-copy-plugin",
-  "description": "Fetch environment variables and write it to a .env file - Maintained fork from https://github.com/Jimdo/serverless-dotenv",
-  "githubUrl": "https://github.com/UnlyEd/serverless-env-copy-plugin",
-  "status": "active"
+    "name": "@unly/serverless-env-copy-plugin",
+    "description": "Fetch environment variables and write it to a .env file - Maintained fork from https://github.com/Jimdo/serverless-dotenv",
+    "githubUrl": "https://github.com/UnlyEd/serverless-env-copy-plugin",
+    "status": "active"
 }, {
-  "name": "@unly/serverless-plugin-dynamodb-backups",
-  "description": "Configure automated DynamoDB \"On-Demand\" backups and manage backups lifecycle, powered by AWS Lambda",
-  "githubUrl": "https://github.com/UnlyEd/serverless-plugin-dynamodb-backups",
-  "status": "active"
+    "name": "@unly/serverless-plugin-dynamodb-backups",
+    "description": "Configure automated DynamoDB \"On-Demand\" backups and manage backups lifecycle, powered by AWS Lambda",
+    "githubUrl": "https://github.com/UnlyEd/serverless-plugin-dynamodb-backups",
+    "status": "active"
 }, {
-  "name": "serverless-convention",
-  "description": "Dynamically import resources by defining a convention, split up your yml",
-  "githubUrl": "https://github.com/LeoPlatform/serverless-convention",
-  "status": "active"
+    "name": "serverless-convention",
+    "description": "Dynamically import resources by defining a convention, split up your yml",
+    "githubUrl": "https://github.com/LeoPlatform/serverless-convention",
+    "status": "active"
 }, {
-  "name": "serverless-openapi-documenter",
-  "description": "A plugin that creates a valid OpenAPI 3.0.X json or yaml schema as well as being able to output a Postman Collection v2 in json.",
-  "githubUrl": "https://github.com/JaredCE/serverless-openapi-documenter",
-  "status": "active"
+    "name": "serverless-openapi-documenter",
+    "description": "A plugin that creates a valid OpenAPI 3.0.X json or yaml schema as well as being able to output a Postman Collection v2 in json.",
+    "githubUrl": "https://github.com/JaredCE/serverless-openapi-documenter",
+    "status": "active"
 }, {
-  "name": "serverless-offline-scheduler",
-  "description": "Runs scheduled functions offline while integrating with serverless-offline",
-  "githubUrl": "https://github.com/ajmath/serverless-offline-scheduler",
-  "status": "active"
+    "name": "serverless-offline-scheduler",
+    "description": "Runs scheduled functions offline while integrating with serverless-offline",
+    "githubUrl": "https://github.com/ajmath/serverless-offline-scheduler",
+    "status": "active"
 }, {
-  "name": "serverless-aws-alias",
-  "description": "This plugin enables use of AWS aliases on Lambda functions.",
-  "githubUrl": "https://github.com/serverless-heaven/serverless-aws-alias",
-  "status": "active"
+    "name": "serverless-aws-alias",
+    "description": "This plugin enables use of AWS aliases on Lambda functions.",
+    "githubUrl": "https://github.com/serverless-heaven/serverless-aws-alias",
+    "status": "active"
 }, {
-  "name": "serverless-plugin-webpack",
-  "description": "A serverless plugin to automatically bundle your functions individually with webpack",
-  "githubUrl": "https://github.com/goldwasserexchange/serverless-plugin-webpack",
-  "status": "active"
+    "name": "serverless-plugin-webpack",
+    "description": "A serverless plugin to automatically bundle your functions individually with webpack",
+    "githubUrl": "https://github.com/goldwasserexchange/serverless-plugin-webpack",
+    "status": "active"
 }, {
-  "name": "serverless-secret-baker",
-  "description": "A Serverless Framework Plugin for secure, performant, and deterministic secret management.",
-  "githubUrl": "https://github.com/vacasaoss/serverless-secret-baker",
-  "status": "active"
+    "name": "serverless-secret-baker",
+    "description": "A Serverless Framework Plugin for secure, performant, and deterministic secret management.",
+    "githubUrl": "https://github.com/vacasaoss/serverless-secret-baker",
+    "status": "active"
 }, {
-  "name": "serverless-sqs-fifo",
-  "description": "A serverless plugin to handle creation of sqs fifo queue's in aws (stop-gap)",
-  "githubUrl": "https://github.com/vortarian/serverless-sqs-fifo",
-  "status": "active"
+    "name": "serverless-sqs-fifo",
+    "description": "A serverless plugin to handle creation of sqs fifo queue's in aws (stop-gap)",
+    "githubUrl": "https://github.com/vortarian/serverless-sqs-fifo",
+    "status": "active"
 }, {
-  "name": "serverless-sqs-alarms-plugin",
-  "description": "Wrapper to setup CloudWatch Alarms on SQS queue length",
-  "githubUrl": "https://github.com/sbstjn/serverless-sqs-alarms-plugin",
-  "status": "inactive"
+    "name": "serverless-sqs-alarms-plugin",
+    "description": "Wrapper to setup CloudWatch Alarms on SQS queue length",
+    "githubUrl": "https://github.com/sbstjn/serverless-sqs-alarms-plugin",
+    "status": "inactive"
 }, {
-  "name": "serverless-dotenv",
-  "description": "Fetch environment variables and write it to a .env file",
-  "githubUrl": "https://github.com/Jimdo/serverless-dotenv",
-  "status": "active"
+    "name": "serverless-dotenv",
+    "description": "Fetch environment variables and write it to a .env file",
+    "githubUrl": "https://github.com/Jimdo/serverless-dotenv",
+    "status": "active"
 }, {
-  "name": "serverless-haskell",
-  "description": "Deploying Haskell applications to AWS Lambda with Serverless",
-  "githubUrl": "https://github.com/seek-oss/serverless-haskell",
-  "status": "active"
+    "name": "serverless-haskell",
+    "description": "Deploying Haskell applications to AWS Lambda with Serverless",
+    "githubUrl": "https://github.com/seek-oss/serverless-haskell",
+    "status": "active"
 }, {
-  "name": "serverless-hooks-plugin",
-  "description": "Run arbitrary commands on any lifecycle event in serverless",
-  "githubUrl": "https://github.com/uswitch/serverless-hooks-plugin",
-  "status": "active"
+    "name": "serverless-hooks-plugin",
+    "description": "Run arbitrary commands on any lifecycle event in serverless",
+    "githubUrl": "https://github.com/uswitch/serverless-hooks-plugin",
+    "status": "active"
 }, {
-  "name": "serverless-offline-watcher",
-  "description": "Run arbitrary commands when files are changed while running serverless-offline",
-  "githubUrl": "https://github.com/domdomegg/serverless-offline-watcher",
-  "status": "active"
+    "name": "serverless-offline-watcher",
+    "description": "Run arbitrary commands when files are changed while running serverless-offline",
+    "githubUrl": "https://github.com/domdomegg/serverless-offline-watcher",
+    "status": "active"
 }, {
-  "name": "serverless-dynalite",
-  "description": "Run dynalite locally (no JVM, all JS) to simulate DynamoDB. Watch serverless.yml for table config updates.",
-  "githubUrl": "https://github.com/sdd/serverless-dynalite",
-  "status": "active"
+    "name": "serverless-dynalite",
+    "description": "Run dynalite locally (no JVM, all JS) to simulate DynamoDB. Watch serverless.yml for table config updates.",
+    "githubUrl": "https://github.com/sdd/serverless-dynalite",
+    "status": "active"
 }, {
-  "name": "serverless-apig-s3",
-  "description": "Serve static front-end content from S3 via the API Gateway and deploy client bundle to S3.",
-  "githubUrl": "https://github.com/sdd/serverless-apig-s3",
-  "status": "active"
+    "name": "serverless-apig-s3",
+    "description": "Serve static front-end content from S3 via the API Gateway and deploy client bundle to S3.",
+    "githubUrl": "https://github.com/sdd/serverless-apig-s3",
+    "status": "active"
 }, {
-  "name": "serverless-plugin-typescript",
-  "description": "Serverless plugin for zero-config Typescript support.",
-  "githubUrl": "https://github.com/graphcool/serverless-plugin-typescript",
-  "status": "active"
+    "name": "serverless-plugin-typescript",
+    "description": "Serverless plugin for zero-config Typescript support.",
+    "githubUrl": "https://github.com/graphcool/serverless-plugin-typescript",
+    "status": "active"
 }, {
-  "name": "serverless-parameters",
-  "description": "Add parameters to the generated cloudformation templates",
-  "githubUrl": "https://github.com/svdgraaf/serverless-parameters",
-  "status": "active"
+    "name": "serverless-parameters",
+    "description": "Add parameters to the generated cloudformation templates",
+    "githubUrl": "https://github.com/svdgraaf/serverless-parameters",
+    "status": "active"
 }, {
-  "name": "serverless-git-commit-tracker",
-  "description": "Generates a version tracking file for web or API deployment containing the latest git commit version number, deployment stage, and date",
-  "githubUrl": "https://github.com/optimator999/serverless-git-commit-tracker",
-  "status": "active"
+    "name": "serverless-git-commit-tracker",
+    "description": "Generates a version tracking file for web or API deployment containing the latest git commit version number, deployment stage, and date",
+    "githubUrl": "https://github.com/optimator999/serverless-git-commit-tracker",
+    "status": "active"
 },{
-  "name": "serverless-plugin-epsagon",
-  "description": "Distributed tracing that helps you monitor and troubleshoot your serverless applications.",
-  "githubUrl": "https://github.com/epsagon/serverless-plugin-epsagon",
-  "status": "active"
+    "name": "serverless-plugin-epsagon",
+    "description": "Distributed tracing that helps you monitor and troubleshoot your serverless applications.",
+    "githubUrl": "https://github.com/epsagon/serverless-plugin-epsagon",
+    "status": "active"
 }, {
-  "name": "serverless-dynamodb-ttl",
-  "description": "Configure DynamoDB TTL in serverless.yml (until CloudFormation supports this).",
-  "githubUrl": "https://github.com/Jimdo/serverless-dynamodb-ttl",
-  "status": "active"
+    "name": "serverless-dynamodb-ttl",
+    "description": "Configure DynamoDB TTL in serverless.yml (until CloudFormation supports this).",
+    "githubUrl": "https://github.com/Jimdo/serverless-dynamodb-ttl",
+    "status": "active"
 }, {
-  "name": "serverless-api-stage",
-  "description": "Serverless API Stage plugin, enables stage variables and logging for AWS API Gateway.",
-  "githubUrl": "https://github.com/leftclickben/serverless-api-stage",
-  "status": "active"
+    "name": "serverless-api-stage",
+    "description": "Serverless API Stage plugin, enables stage variables and logging for AWS API Gateway.",
+    "githubUrl": "https://github.com/leftclickben/serverless-api-stage",
+    "status": "active"
 },{
-  "name": "serverless-plugin-lambda-insights",
-  "description": "A Serverless Framework Plugin allowing to enable Lambda Insights.",
-  "githubUrl": "https://github.com/awslabs/serverless-plugin-lambda-insights",
-  "status": "active"
+    "name": "serverless-plugin-lambda-insights",
+    "description": "A Serverless Framework Plugin allowing to enable Lambda Insights.",
+    "githubUrl": "https://github.com/awslabs/serverless-plugin-lambda-insights",
+    "status": "active"
 },
-  {
+ {
     "name": "serverless-export-env",
     "description": "Export environment variables into a .env file with automatic AWS CloudFormation reference resolution.",
     "githubUrl": "https://github.com/arabold/serverless-export-env",
     "status": "active"
-  }, {
-  "name": "serverless-package-python-functions",
-  "description": "Packaging Python Lambda functions with only the dependencies/requirements they need.",
-  "githubUrl": "https://github.com/ubaniabalogun/serverless-package-python-functions",
-  "status": "active"
 }, {
-  "name": "serverless-plugin-iopipe",
-  "description": "See inside your Lambda functions with high fidelity metrics and monitoring.",
-  "githubUrl": "https://github.com/iopipe/serverless-plugin-iopipe",
-  "status": "active"
+    "name": "serverless-package-python-functions",
+    "description": "Packaging Python Lambda functions with only the dependencies/requirements they need.",
+    "githubUrl": "https://github.com/ubaniabalogun/serverless-package-python-functions",
+    "status": "active"
 }, {
-  "name": "serverless-plugin-metric",
-  "description": "Creates dynamically AWS metric-filter resources with custom patterns",
-  "githubUrl": "https://github.com/alex20465/serverless-plugin-metric",
-  "status": "active"
+    "name": "serverless-plugin-iopipe",
+    "description": "See inside your Lambda functions with high fidelity metrics and monitoring.",
+    "githubUrl": "https://github.com/iopipe/serverless-plugin-iopipe",
+    "status": "active"
 }, {
-  "name": "serverless-sam",
-  "description": "Exports an AWS SAM template for a service created with the Serverless Framework.",
-  "githubUrl": "https://github.com/SAPessi/serverless-sam",
-  "status": "active"
+    "name": "serverless-plugin-metric",
+    "description": "Creates dynamically AWS metric-filter resources with custom patterns",
+    "githubUrl": "https://github.com/alex20465/serverless-plugin-metric",
+    "status": "active"
 }, {
-  "name": "serverless-vpc-discovery",
-  "description": "Serverless plugin for discovering VPC / Subnet / Security Group configuration by name.",
-  "githubUrl": "https://github.com/amplify-education/serverless-vpc-discovery",
-  "status": "active"
+    "name": "serverless-sam",
+    "description": "Exports an AWS SAM template for a service created with the Serverless Framework.",
+    "githubUrl": "https://github.com/SAPessi/serverless-sam",
+    "status": "active"
 }, {
-  "name": "serverless-kubeless",
-  "description": "Serverless plugin for deploying functions to Kubeless.",
-  "githubUrl": "https://github.com/serverless/serverless-kubeless",
-  "status": "active"
+    "name": "serverless-vpc-discovery",
+    "description": "Serverless plugin for discovering VPC / Subnet / Security Group configuration by name.",
+    "githubUrl": "https://github.com/amplify-education/serverless-vpc-discovery",
+    "status": "active"
 }, {
-  "name": "serverless-kubeless-offline",
-  "description": "Simulates Kubeless NodeJS runtimes to run/call your functions offline using the Serverless Framework.",
-  "githubUrl": "https://github.com/usefulio/serverless-kubeless-offline",
-  "status": "active"
+    "name": "serverless-kubeless",
+    "description": "Serverless plugin for deploying functions to Kubeless.",
+    "githubUrl": "https://github.com/serverless/serverless-kubeless",
+    "status": "active"
 }, {
-  "name": "serverless-apigwy-binary",
-  "description": "Serverless plugin for configuring API Gateway to return binary responses",
-  "githubUrl": "https://github.com/ryanmurakami/serverless-apigwy-binary",
-  "status": "active"
+    "name": "serverless-kubeless-offline",
+    "description": "Simulates Kubeless NodeJS runtimes to run/call your functions offline using the Serverless Framework.",
+    "githubUrl": "https://github.com/usefulio/serverless-kubeless-offline",
+    "status": "active"
 }, {
-  "name": "serverless-plugin-browserifier",
-  "description": "Reduce the size and speed up your Node.js based lambda's using browserify.",
-  "githubUrl": "https://github.com/digitalmaas/serverless-plugin-browserifier",
-  "status": "active"
+    "name": "serverless-apigwy-binary",
+    "description": "Serverless plugin for configuring API Gateway to return binary responses",
+    "githubUrl": "https://github.com/ryanmurakami/serverless-apigwy-binary",
+    "status": "active"
 }, {
-  "name": "@digitalmaas/serverless-plugin-sqs-alarms",
-  "description": "Simplifies the setup of CloudWatch Alarms to monitor the visible messages in an SQS queue.",
-  "githubUrl": "https://github.com/digitalmaas/serverless-plugin-sqs-alarms",
-  "status": "active"
+    "name": "serverless-plugin-browserifier",
+    "description": "Reduce the size and speed up your Node.js based lambda's using browserify.",
+    "githubUrl": "https://github.com/digitalmaas/serverless-plugin-browserifier",
+    "status": "active"
 }, {
-  "name": "serverless-shell",
-  "description": "Drop to a runtime shell with all the environment variables set that you'd have in lambda.",
-  "githubUrl": "https://github.com/UnitedIncome/serverless-shell",
-  "status": "active"
+    "name": "@digitalmaas/serverless-plugin-sqs-alarms",
+    "description": "Simplifies the setup of CloudWatch Alarms to monitor the visible messages in an SQS queue.",
+    "githubUrl": "https://github.com/digitalmaas/serverless-plugin-sqs-alarms",
+    "status": "active"
 }, {
-  "name": "serverless-stack-output",
-  "description": "Store output from your AWS CloudFormation Stack in JSON/YAML/TOML files, or to pass it to a JavaScript function for further processing.",
-  "githubUrl": "https://github.com/sbstjn/serverless-stack-output",
-  "status": "active"
+    "name": "serverless-shell",
+    "description": "Drop to a runtime shell with all the environment variables set that you'd have in lambda.",
+    "githubUrl": "https://github.com/UnitedIncome/serverless-shell",
+    "status": "active"
 }, {
-  "name": "serverless-gulp",
-  "description": "A thin task wrapper around @goserverless that allows you to automate build, test and deploy tasks using gulp",
-  "githubUrl": "https://github.com/rhythminme/serverless-gulp",
-  "status": "active"
+    "name": "serverless-stack-output",
+    "description": "Store output from your AWS CloudFormation Stack in JSON/YAML/TOML files, or to pass it to a JavaScript function for further processing.",
+    "githubUrl": "https://github.com/sbstjn/serverless-stack-output",
+    "status": "active"
 }, {
-  "name": "serverless-google-cloudfunctions",
-  "description": "This plugin enables support for Google Cloud Functions within the Serverless Framework.",
-  "githubUrl": "https://github.com/serverless/serverless-google-cloudfunctions",
-  "status": "active"
+    "name": "serverless-gulp",
+    "description": "A thin task wrapper around @goserverless that allows you to automate build, test and deploy tasks using gulp",
+    "githubUrl": "https://github.com/rhythminme/serverless-gulp",
+    "status": "active"
 }, {
-  "name": "serverless-azure-functions",
-  "description": "A Serverless plugin that adds Azure Functions support to the Serverless Framework.",
-  "githubUrl": "https://github.com/serverless/serverless-azure-functions",
-  "status": "active"
+    "name": "serverless-google-cloudfunctions",
+    "description": "This plugin enables support for Google Cloud Functions within the Serverless Framework.",
+    "githubUrl": "https://github.com/serverless/serverless-google-cloudfunctions",
+    "status": "active"
 }, {
-  "name": "serverless-sentry",
-  "description": "Automatic monitoring of memory usage, execution timeouts and forwarding of Lambda errors to Sentry (https://sentry.io).",
-  "githubUrl": "https://github.com/arabold/serverless-sentry-plugin",
-  "status": "active"
+    "name": "serverless-azure-functions",
+    "description": "A Serverless plugin that adds Azure Functions support to the Serverless Framework.",
+    "githubUrl": "https://github.com/serverless/serverless-azure-functions",
+    "status": "active"
 }, {
-  "name": "serverless-env-generator",
-  "description": "Manage environment variables with YAML and load them with dotenv. Supports variable encryption with KMS, multiple stages and custom profiles.",
-  "githubUrl": "https://github.com/DieProduktMacher/serverless-env-generator",
-  "status": "active"
+    "name": "serverless-sentry",
+    "description": "Automatic monitoring of memory usage, execution timeouts and forwarding of Lambda errors to Sentry (https://sentry.io).",
+    "githubUrl": "https://github.com/arabold/serverless-sentry-plugin",
+    "status": "active"
 }, {
-  "name": "@redtea/serverless-env-generator",
-  "description": "Manage environment variables with YAML and load them with dotenv. Supports variable encryption with KMS, multiple stages and custom profiles. Maintained fork from https://github.com/DieProduktMacher/serverless-env-generator with more advanced YAML anchors supporting and other.",
-  "githubUrl": "https://github.com/org-redtea/serverless-env-generator",
-  "status": "active"
+    "name": "serverless-env-generator",
+    "description": "Manage environment variables with YAML and load them with dotenv. Supports variable encryption with KMS, multiple stages and custom profiles.",
+    "githubUrl": "https://github.com/DieProduktMacher/serverless-env-generator",
+    "status": "active"
+}, {
+    "name": "@redtea/serverless-env-generator",
+    "description": "Manage environment variables with YAML and load them with dotenv. Supports variable encryption with KMS, multiple stages and custom profiles. Maintained fork from https://github.com/DieProduktMacher/serverless-env-generator with more advanced YAML anchors supporting and other.",
+    "githubUrl": "https://github.com/org-redtea/serverless-env-generator",
+    "status": "active"
 }, {
   "name": "@agiledigital/serverless-sns-sqs-lambda",
   "description": "Provide the lambda function with the snsSqs event, the plugin will add the AWS SNS topic and subscription, SQS queue and dead letter queue, and the role need for the lambda.",
   "githubUrl": "https://github.com/agiledigital/serverless-sns-sqs-lambda",
   "status": "active"
 }, {
-  "name": "serverless-plugin-embedded-env-in-code",
-  "description": "Replace environment variables with static strings before deployment. It’s for Lambda@Edge.",
-  "githubUrl": "https://github.com/zaru/serverless-plugin-embedded-env-in-code",
-  "status": "active"
+    "name": "serverless-plugin-embedded-env-in-code",
+    "description": "Replace environment variables with static strings before deployment. It’s for Lambda@Edge.",
+    "githubUrl": "https://github.com/zaru/serverless-plugin-embedded-env-in-code",
+    "status": "active"
 }, {
-  "name": "serverless-local-dev-server",
-  "description": "Speeds up development of Alexa Skills, Chatbots and APIs by exposing your functions as local HTTP endpoints and mapping received events.",
-  "githubUrl": "https://github.com/DieProduktMacher/serverless-local-dev-server",
-  "status": "active"
+    "name": "serverless-local-dev-server",
+    "description": "Speeds up development of Alexa Skills, Chatbots and APIs by exposing your functions as local HTTP endpoints and mapping received events.",
+    "githubUrl": "https://github.com/DieProduktMacher/serverless-local-dev-server",
+    "status": "active"
 }, {
-  "name": "serverless-plugin-stack-config",
-  "description": "A serverless plugin to manage configurations for a stack across micro-services.",
-  "githubUrl": "https://github.com/rawphp/serverless-plugin-stack-config",
-  "status": "active"
+    "name": "serverless-plugin-stack-config",
+    "description": "A serverless plugin to manage configurations for a stack across micro-services.",
+    "githubUrl": "https://github.com/rawphp/serverless-plugin-stack-config",
+    "status": "active"
 }, {
-  "name": "serverless-plugin-elastic-beanstalk",
-  "description": "A serverless plugin to deploy applications to AWS ElasticBeanstalk.",
-  "githubUrl": "https://github.com/rawphp/serverless-plugin-elastic-beanstalk",
-  "status": "active"
+    "name": "serverless-plugin-elastic-beanstalk",
+    "description": "A serverless plugin to deploy applications to AWS ElasticBeanstalk.",
+    "githubUrl": "https://github.com/rawphp/serverless-plugin-elastic-beanstalk",
+    "status": "active"
 }, {
-  "name": "serverless-s3-local",
-  "description": "A serverless plugin to run a S3 clone on your local machine",
-  "githubUrl": "https://github.com/ar90n/serverless-s3-local",
-  "status": "active"
+    "name": "serverless-s3-local",
+    "description": "A serverless plugin to run a S3 clone on your local machine",
+    "githubUrl": "https://github.com/ar90n/serverless-s3-local",
+    "status": "active"
 }, {
-  "name": "serverless-s3-remover",
-  "description": "A serverless plugin to make s3 buckets empty before deleting cloudformation stack when ```sls remove```",
-  "githubUrl": "https://github.com/sinofseven/serverless-s3-remover",
-  "status": "active"
+    "name": "serverless-s3-remover",
+    "description": "A serverless plugin to make s3 buckets empty before deleting cloudformation stack when ```sls remove```",
+    "githubUrl": "https://github.com/sinofseven/serverless-s3-remover",
+    "status": "active"
 }, {
-  "name": "serverless-dynamodb-autoscaling",
-  "description": "Configure Amazon DynamoDB's native Auto Scaling for your table capacities.",
-  "githubUrl": "https://github.com/sbstjn/serverless-dynamodb-autoscaling",
-  "status": "active"
+    "name": "serverless-dynamodb-autoscaling",
+    "description": "Configure Amazon DynamoDB's native Auto Scaling for your table capacities.",
+    "githubUrl": "https://github.com/sbstjn/serverless-dynamodb-autoscaling",
+    "status": "active"
 }, {
-  "name": "serverless-plugin-bespoken",
-  "description": "Creates a local server and a proxy so you don't have to deploy anytime you want to test your code",
-  "githubUrl": "https://github.com/bespoken/serverless-plugin-bespoken",
-  "status": "active"
+    "name": "serverless-plugin-bespoken",
+    "description": "Creates a local server and a proxy so you don't have to deploy anytime you want to test your code",
+    "githubUrl": "https://github.com/bespoken/serverless-plugin-bespoken",
+    "status": "active"
 }, {
-  "name": "serverless-s3bucket-sync",
-  "description": "Sync a local folder with a S3 bucket after sls deploy",
-  "githubUrl": "https://github.com/sbstjn/serverless-s3bucket-sync",
-  "status": "active"
+    "name": "serverless-s3bucket-sync",
+    "description": "Sync a local folder with a S3 bucket after sls deploy",
+    "githubUrl": "https://github.com/sbstjn/serverless-s3bucket-sync",
+    "status": "active"
 }, {
-  "name": "serverless-s3-sync",
-  "description": "A plugin to sync local directories and S3 prefixes for Serverless Framework,",
-  "githubUrl": "https://github.com/k1LoW/serverless-s3-sync",
-  "status": "active"
+    "name": "serverless-s3-sync",
+    "description": "A plugin to sync local directories and S3 prefixes for Serverless Framework,",
+    "githubUrl": "https://github.com/k1LoW/serverless-s3-sync",
+    "status": "active"
 }, {
-  "name": "serverless-build-client",
-  "description": "Build your static website with environment variables defined in serverless.yml",
-  "githubUrl": "https://github.com/tgfischer/serverless-build-client",
-  "status": "active"
+    "name": "serverless-build-client",
+    "description": "Build your static website with environment variables defined in serverless.yml",
+    "githubUrl": "https://github.com/tgfischer/serverless-build-client",
+    "status": "active"
 }, {
-  "name": "serverless-nested-stack",
-  "description": "A plugin to Workaround for Cloudformation 200 resource limit",
-  "githubUrl": "https://github.com/jagdish-176/serverless-nested-stack",
-  "status": "active"
+    "name": "serverless-nested-stack",
+    "description": "A plugin to Workaround for Cloudformation 200 resource limit",
+    "githubUrl": "https://github.com/jagdish-176/serverless-nested-stack",
+    "status": "active"
 }, {
-  "name": "serverless-plugin-common-excludes",
-  "description": "Adds commonly excluded files to package.excludes",
-  "githubUrl": "https://github.com/dougmoscrop/serverless-plugin-common-excludes",
-  "status": "active"
+    "name": "serverless-plugin-common-excludes",
+    "description": "Adds commonly excluded files to package.excludes",
+    "githubUrl": "https://github.com/dougmoscrop/serverless-plugin-common-excludes",
+    "status": "active"
 }, {
-  "name": "serverless-plugin-custom-domain",
-  "description": "Reliably sets a BasePathMapping to an API Gateway Custom Domain",
-  "githubUrl": "https://github.com/dougmoscrop/serverless-plugin-custom-domain",
-  "status": "active"
+    "name": "serverless-plugin-custom-domain",
+    "description": "Reliably sets a BasePathMapping to an API Gateway Custom Domain",
+    "githubUrl": "https://github.com/dougmoscrop/serverless-plugin-custom-domain",
+    "status": "active"
 }, {
-  "name": "serverless-plugin-split-stacks",
-  "description": "Migrate certain resources to nested stacks",
-  "githubUrl": "https://github.com/dougmoscrop/serverless-plugin-split-stacks",
-  "status": "active"
+    "name": "serverless-plugin-split-stacks",
+    "description": "Migrate certain resources to nested stacks",
+    "githubUrl": "https://github.com/dougmoscrop/serverless-plugin-split-stacks",
+    "status": "active"
 }, {
-  "name": "serverless-plugin-log-subscription",
-  "description": "Adds a CloudWatch LogSubscription for functions",
-  "githubUrl": "https://github.com/dougmoscrop/serverless-plugin-log-subscription",
-  "status": "active"
+    "name": "serverless-plugin-log-subscription",
+    "description": "Adds a CloudWatch LogSubscription for functions",
+    "githubUrl": "https://github.com/dougmoscrop/serverless-plugin-log-subscription",
+    "status": "active"
 }, {
-  "name": "serverless-cf-vars",
-  "description": "Enables use of AWS pseudo functions and Fn::Sub string substitution",
-  "githubUrl": "https://gitlab.com/kabo/serverless-cf-vars",
-  "status": "active"
+    "name": "serverless-cf-vars",
+    "description": "Enables use of AWS pseudo functions and Fn::Sub string substitution",
+    "githubUrl": "https://gitlab.com/kabo/serverless-cf-vars",
+    "status": "active"
 }, {
-  "name": "serverless-apigateway-plugin",
-  "description": "Configure the AWS api gateway: Binary support, Headers and Body template mappings",
-  "githubUrl": "https://github.com/GFG/serverless-apigateway-plugin",
-  "status": "active"
+    "name": "serverless-apigateway-plugin",
+    "description": "Configure the AWS api gateway: Binary support, Headers and Body template mappings",
+    "githubUrl": "https://github.com/GFG/serverless-apigateway-plugin",
+    "status": "active"
 }, {
-  "name": "serverless-plugin-deploy-environment",
-  "description": "Plugin to manage deployment environment across stages",
-  "githubUrl": "https://github.com/DopplerLabs/serverless-plugin-deploy-environment",
-  "status": "active"
+    "name": "serverless-plugin-deploy-environment",
+    "description": "Plugin to manage deployment environment across stages",
+    "githubUrl": "https://github.com/DopplerLabs/serverless-plugin-deploy-environment",
+    "status": "active"
 }, {
-  "name": "serverless-import-config-plugin",
-  "description": "Import YAML files in serverless.yaml config file",
-  "githubUrl": "https://github.com/KrysKruk/serverless-import-config-plugin",
-  "status": "active"
+    "name": "serverless-import-config-plugin",
+    "description": "Import YAML files in serverless.yaml config file",
+    "githubUrl": "https://github.com/KrysKruk/serverless-import-config-plugin",
+    "status": "active"
 }, {
-  "name": "serverless-plugin-aws-resolvers",
-  "description": "Resolves variables from ESS, RDS, or Kinesis for serverless services",
-  "githubUrl": "https://github.com/DopplerLabs/serverless-plugin-aws-resolvers",
-  "status": "active"
+    "name": "serverless-plugin-aws-resolvers",
+    "description": "Resolves variables from ESS, RDS, or Kinesis for serverless services",
+    "githubUrl": "https://github.com/DopplerLabs/serverless-plugin-aws-resolvers",
+    "status": "active"
 }, {
-  "name": "serverless-plugin-offline-kinesis-events",
-  "description": "Plugin that works with serverless-offline to allow offline testing of serverless functions that are triggered by Kinesis events.",
-  "githubUrl": "https://github.com/DopplerLabs/serverless-plugin-offline-kinesis-events",
-  "status": "active"
+    "name": "serverless-plugin-offline-kinesis-events",
+    "description": "Plugin that works with serverless-offline to allow offline testing of serverless functions that are triggered by Kinesis events.",
+    "githubUrl": "https://github.com/DopplerLabs/serverless-plugin-offline-kinesis-events",
+    "status": "active"
 }, {
-  "name": "serverless-micro",
-  "description": "Plugin to help manage multiple micro services under one main service.",
-  "githubUrl": "https://github.com/barstoolsports/serverless-micro",
-  "status": "active"
+    "name": "serverless-micro",
+    "description": "Plugin to help manage multiple micro services under one main service.",
+    "githubUrl": "https://github.com/barstoolsports/serverless-micro",
+    "status": "active"
 }, {
-  "name": "serverless-api-cloudfront",
-  "description": "Plugin that adds CloudFront distribution in front of your API Gateway for custom domain, CDN caching and access log.",
-  "githubUrl": "https://github.com/Droplr/serverless-api-cloudfront",
-  "status": "active"
+    "name": "serverless-api-cloudfront",
+    "description": "Plugin that adds CloudFront distribution in front of your API Gateway for custom domain, CDN caching and access log.",
+    "githubUrl": "https://github.com/Droplr/serverless-api-cloudfront",
+    "status": "active"
 }, {
-  "name": "serverless-offline-sns",
-  "description": "Serverless plugin to run a local SNS server and call serverless SNS handlers with events notifications.",
-  "githubUrl": "https://github.com/mj1618/serverless-offline-sns",
-  "status": "active"
+    "name": "serverless-offline-sns",
+    "description": "Serverless plugin to run a local SNS server and call serverless SNS handlers with events notifications.",
+    "githubUrl": "https://github.com/mj1618/serverless-offline-sns",
+    "status": "active"
 }, {
-  "name": "serverless-stage-manager",
-  "description": "Super simple Serverless plugin for validating stage names before deployment",
-  "githubUrl": "https://github.com/jeremydaly/serverless-stage-manager",
-  "status": "active"
+    "name": "serverless-stage-manager",
+    "description": "Super simple Serverless plugin for validating stage names before deployment",
+    "githubUrl": "https://github.com/jeremydaly/serverless-stage-manager",
+    "status": "active"
 }, {
-  "name": "serverless-lift",
-  "description": "Deploy high-level components such as static websites, buckets, queues, webhooks...",
-  "githubUrl": "https://github.com/getlift/lift",
-  "status": "active"
+    "name": "serverless-lift",
+    "description": "Deploy high-level components such as static websites, buckets, queues, webhooks...",
+    "githubUrl": "https://github.com/getlift/lift",
+    "status": "active"
 }, {
-  "name": "serverless-spa",
-  "description": "Serverless plugin to deploy your website to AWS S3 using Webpack to bundle it.",
-  "githubUrl": "https://github.com/gilmarsquinelato/serverless-spa",
-  "status": "active"
+    "name": "serverless-spa",
+    "description": "Serverless plugin to deploy your website to AWS S3 using Webpack to bundle it.",
+    "githubUrl": "https://github.com/gilmarsquinelato/serverless-spa",
+    "status": "active"
 }, {
-  "name": "serverless-aws-nested-stacks",
-  "description": "Yet another AWS nested stack plugin!",
-  "githubUrl": "https://github.com/concon121/serverless-plugin-nested-stacks",
-  "status": "active"
+    "name": "serverless-aws-nested-stacks",
+    "description": "Yet another AWS nested stack plugin!",
+    "githubUrl": "https://github.com/concon121/serverless-plugin-nested-stacks",
+    "status": "active"
 }, {
-  "name": "serverless-aws-resource-names",
-  "description": "Serverless plugin to alter the default naming conventions for sls resources via a simple mapping file.",
-  "githubUrl": "https://github.com/concon121/serverless-plugin-aws-resource-names",
-  "status": "active"
+    "name": "serverless-aws-resource-names",
+    "description": "Serverless plugin to alter the default naming conventions for sls resources via a simple mapping file.",
+    "githubUrl": "https://github.com/concon121/serverless-plugin-aws-resource-names",
+    "status": "active"
 }, {
-  "name": "serverless-attach-managed-policy",
-  "description": "A Serverless plugin to automatically attach an AWS Managed IAM Policy (or Policies) to all IAM Roles created by the Service.",
-  "githubUrl": "https://github.com/Nordstrom/serverless-attach-managed-policy",
-  "status": "active"
+    "name": "serverless-attach-managed-policy",
+    "description": "A Serverless plugin to automatically attach an AWS Managed IAM Policy (or Policies) to all IAM Roles created by the Service.",
+    "githubUrl": "https://github.com/Nordstrom/serverless-attach-managed-policy",
+    "status": "active"
 }, {
-  "name": "serverless-plugin-reducer",
-  "description": "Reduce Node.js lambda package so it contains only lambda dependencies",
-  "githubUrl": "https://github.com/medikoo/serverless-plugin-reducer",
-  "status": "active"
+    "name": "serverless-plugin-reducer",
+    "description": "Reduce Node.js lambda package so it contains only lambda dependencies",
+    "githubUrl": "https://github.com/medikoo/serverless-plugin-reducer",
+    "status": "active"
 }, {
-  "name": "serverless-plugin-transpiler",
-  "description": "Transpile lambda files during packaging step",
-  "githubUrl": "https://github.com/medikoo/serverless-plugin-transpiler",
-  "status": "active"
+    "name": "serverless-plugin-transpiler",
+    "description": "Transpile lambda files during packaging step",
+    "githubUrl": "https://github.com/medikoo/serverless-plugin-transpiler",
+    "status": "active"
 }, {
-  "name": "serverless-plugin-dynamodb-autoscaling",
-  "description": "Auto generate auto scaling configuration for configured DynamoDB tables",
-  "githubUrl": "https://github.com/medikoo/serverless-plugin-dynamodb-autoscaling",
-  "status": "active"
+    "name": "serverless-plugin-dynamodb-autoscaling",
+    "description": "Auto generate auto scaling configuration for configured DynamoDB tables",
+    "githubUrl": "https://github.com/medikoo/serverless-plugin-dynamodb-autoscaling",
+    "status": "active"
 }, {
-  "name": "serverless-plugin-vpc-eni-cleanup",
-  "description": "Automatic cleanup of VPC network interfaces on stage removal",
-  "githubUrl": "https://github.com/medikoo/serverless-plugin-vpc-eni-cleanup",
-  "status": "active"
+    "name": "serverless-plugin-vpc-eni-cleanup",
+    "description": "Automatic cleanup of VPC network interfaces on stage removal",
+    "githubUrl": "https://github.com/medikoo/serverless-plugin-vpc-eni-cleanup",
+    "status": "active"
 }, {
-  "name": "serverless-plugin-tracer",
-  "description": "Trace serverless hooks as they execute",
-  "githubUrl": "https://github.com/enykeev/serverless-plugin-tracer",
-  "status": "active"
+    "name": "serverless-plugin-tracer",
+    "description": "Trace serverless hooks as they execute",
+    "githubUrl": "https://github.com/enykeev/serverless-plugin-tracer",
+    "status": "active"
 }, {
-  "name": "serverless-plugin-stackstorm",
-  "description": "Reusable Functions from StackStorm Exchange",
-  "githubUrl": "https://github.com/StackStorm/serverless-plugin-stackstorm",
-  "status": "active"
+    "name": "serverless-plugin-stackstorm",
+    "description": "Reusable Functions from StackStorm Exchange",
+    "githubUrl": "https://github.com/StackStorm/serverless-plugin-stackstorm",
+    "status": "active"
 }, {
-  "name": "serverless-iot-local",
-  "description": "AWS Iot events with serverless-offline",
-  "githubUrl": "https://github.com/tradle/serverless-iot-local",
-  "status": "active"
+    "name": "serverless-iot-local",
+    "description": "AWS Iot events with serverless-offline",
+    "githubUrl": "https://github.com/tradle/serverless-iot-local",
+    "status": "active"
 }, {
-  "name": "serverless-sns-filter",
-  "description": "Serverless plugin to add SNS Subscription Filters to events",
-  "githubUrl": "https://github.com/MechanicalRock/serverless-sns-filter",
-  "status": "active"
+    "name": "serverless-sns-filter",
+    "description": "Serverless plugin to add SNS Subscription Filters to events",
+    "githubUrl": "https://github.com/MechanicalRock/serverless-sns-filter",
+    "status": "active"
 }, {
-  "name": "serverless-apigateway-route-settings",
-  "description": "Configure Route Settings for HTTP API Gateway v2 (Throttling & Detailed Metrics)",
-  "githubUrl": "https://github.com/talbotp/serverless-apigateway-route-settings",
-  "status": "active"
+    "name": "serverless-apigateway-route-settings",
+    "description": "Configure Route Settings for HTTP API Gateway v2 (Throttling & Detailed Metrics)",
+    "githubUrl": "https://github.com/talbotp/serverless-apigateway-route-settings",
+    "status": "active"
 }, {
-  "name": "serverless-plugin-tagsns",
-  "description": "Serverless plugin to add Tags to SNS Topics",
-  "githubUrl": "https://github.com/ManoManoTech/serverless-plugin-tagsns",
-  "status": "active"
+    "name": "serverless-plugin-tagsns",
+    "description": "Serverless plugin to add Tags to SNS Topics",
+    "githubUrl": "https://github.com/ManoManoTech/serverless-plugin-tagsns",
+    "status": "active"
 }, {
-  "name": "serverless-reqvalidator-plugin",
-  "description": "Serverless plugin to add request validator to API Gateway methods",
-  "githubUrl": "https://github.com/RafPe/serverless-reqvalidator-plugin",
-  "status": "active"
+    "name": "serverless-reqvalidator-plugin",
+    "description": "Serverless plugin to add request validator to API Gateway methods",
+    "githubUrl": "https://github.com/RafPe/serverless-reqvalidator-plugin",
+    "status": "active"
 }, {
-  "name": "serverless-plugin-conditional-functions",
-  "description": "A plugin that allows adding simple feature flag per function via a boolean condition.",
-  "githubUrl": "https://github.com/go-dima/serverless-plugin-conditional-functions",
-  "status": "active"
+    "name": "serverless-plugin-conditional-functions",
+    "description": "A plugin that allows adding simple feature flag per function via a boolean condition.",
+    "githubUrl": "https://github.com/go-dima/serverless-plugin-conditional-functions",
+    "status": "active"
 }, {
-  "name": "serverless-ephemeral",
-  "description": "Build and include custom stateless libraries for any language",
-  "githubUrl": "https://github.com/Accenture/serverless-ephemeral",
-  "status": "active"
+    "name": "serverless-ephemeral",
+    "description": "Build and include custom stateless libraries for any language",
+    "githubUrl": "https://github.com/Accenture/serverless-ephemeral",
+    "status": "active"
 }, {
-  "name": "serverless-content-encoding",
-  "description": "Enable Content Encoding in AWS API Gateway during deployment",
-  "githubUrl": "https://github.com/dong-dohai/serverless-content-encoding",
-  "status": "active"
+    "name": "serverless-content-encoding",
+    "description": "Enable Content Encoding in AWS API Gateway during deployment",
+    "githubUrl": "https://github.com/dong-dohai/serverless-content-encoding",
+    "status": "active"
 }, {
-  "name": "serverless-s3-encryption",
-  "description": "Set or remove the encryption settings on your s3 buckets",
-  "githubUrl": "https://github.com/tradle/serverless-s3-encryption",
-  "status": "active"
+    "name": "serverless-s3-encryption",
+    "description": "Set or remove the encryption settings on your s3 buckets",
+    "githubUrl": "https://github.com/tradle/serverless-s3-encryption",
+    "status": "active"
 }, {
-  "name": "serverless-plugin-inject-dependencies",
-  "description": "Painlessly deploy serverless projects with only the required dependencies.",
-  "githubUrl": "https://github.com/loanmarket/serverless-plugin-inject-dependencies",
-  "status": "active"
+    "name": "serverless-plugin-inject-dependencies",
+    "description": "Painlessly deploy serverless projects with only the required dependencies.",
+    "githubUrl": "https://github.com/loanmarket/serverless-plugin-inject-dependencies",
+    "status": "active"
 }, {
-  "name": "serverless-plugin-provider-groups",
-  "description": "A plugin to allow management of grouped settings within large serverless projects.",
-  "githubUrl": "https://github.com/loanmarket/serverless-plugin-provider-groups",
-  "status": "active"
+    "name": "serverless-plugin-provider-groups",
+    "description": "A plugin to allow management of grouped settings within large serverless projects.",
+    "githubUrl": "https://github.com/loanmarket/serverless-plugin-provider-groups",
+    "status": "active"
 }, {
-  "name": "serverless-cloudformation-resource-counter",
-  "description": "A plugin to count the resources generated in the AWS CloudFormation stack after deployment.",
-  "githubUrl": "https://github.com/drexler/serverless-cloudformation-resource-counter",
-  "status": "active"
+    "name": "serverless-cloudformation-resource-counter",
+    "description": "A plugin to count the resources generated in the AWS CloudFormation stack after deployment.",
+    "githubUrl": "https://github.com/drexler/serverless-cloudformation-resource-counter",
+    "status": "active"
 }, {
-  "name": "serverless-iam-roles-per-function",
-  "description": "Serverless Plugin for easily defining IAM roles per function via the use of iamRoleStatements at the function level.",
-  "githubUrl": "https://github.com/functionalone/serverless-iam-roles-per-function",
-  "status": "active"
+    "name": "serverless-iam-roles-per-function",
+    "description": "Serverless Plugin for easily defining IAM roles per function via the use of iamRoleStatements at the function level.",
+    "githubUrl": "https://github.com/functionalone/serverless-iam-roles-per-function",
+    "status": "active"
 }, {
-  "name": "serverless-frontend-plugin",
-  "description": "Deploy any type of frontend on AWS Cloudfront with Https/SSL termination with your serverless deployments. Integrates with serverless-offline for local development.",
-  "githubUrl": "https://github.com/rogersgt/serverless-frontend-plugin",
-  "status": "active"
+    "name": "serverless-frontend-plugin",
+    "description": "Deploy any type of frontend on AWS Cloudfront with Https/SSL termination with your serverless deployments. Integrates with serverless-offline for local development.",
+    "githubUrl": "https://github.com/rogersgt/serverless-frontend-plugin",
+    "status": "active"
 }, {
-  "name": "@fernthedev/serverless-offline-step-functions",
-  "description": "Serverless Offline Plugin to Support Step Functions for Local Development.",
-  "githubUrl": "https://github.com/jefer590/serverless-offline-step-functions",
-  "status": "active"
+    "name": "@fernthedev/serverless-offline-step-functions",
+    "description": "Serverless Offline Plugin to Support Step Functions for Local Development.",
+    "githubUrl": "https://github.com/jefer590/serverless-offline-step-functions",
+    "status": "active"
 },  {
-  "name": "serverless-functions-base-path",
-  "description": "Easily define a base path where your serverless functions are located.",
-  "githubUrl": "https://github.com/kevinrambaud/serverless-functions-base-path",
-  "status": "active"
+    "name": "serverless-functions-base-path",
+    "description": "Easily define a base path where your serverless functions are located.",
+    "githubUrl": "https://github.com/kevinrambaud/serverless-functions-base-path",
+    "status": "active"
 }, {
-  "name": "serverless-static",
-  "description": "Easily serve files from a folder while developing on localhost with the serverless-offline plugin",
-  "githubUrl": "https://github.com/iliasbhal/serverless-static",
-  "status": "active"
+    "name": "serverless-static",
+    "description": "Easily serve files from a folder while developing on localhost with the serverless-offline plugin",
+    "githubUrl": "https://github.com/iliasbhal/serverless-static",
+    "status": "active"
 }, {
-  "name": "serverless-plugin-static",
-  "description": "Serving static files locally with serverless-offline or a standalone command",
-  "githubUrl": "https://github.com/a-pavlenko/serverless-plugin-static",
-  "status": "active"
+    "name": "serverless-plugin-static",
+    "description": "Serving static files locally with serverless-offline or a standalone command",
+    "githubUrl": "https://github.com/a-pavlenko/serverless-plugin-static",
+    "status": "active"
 }, {
-  "name": "serverless-plugin-node-shim",
-  "description": "Serverless plugin to run your functions in nodejs version (8 LTS, 9+) on aws lambda",
-  "githubUrl": "https://github.com/jzimmek/serverless-plugin-node-shim",
-  "status": "active"
+    "name": "serverless-plugin-node-shim",
+    "description": "Serverless plugin to run your functions in nodejs version (8 LTS, 9+) on aws lambda",
+    "githubUrl": "https://github.com/jzimmek/serverless-plugin-node-shim",
+    "status": "active"
 }, {
-  "name": "serverless-sagemaker-groundtruth",
-  "description": "Serverless Plugin with AWS Sagemaker Groundtruth utilities (local template testing, e2e tests ...)",
-  "githubUrl": "https://github.com/piercus/serverless-sagemaker-groundtruth",
-  "status": "active"
+    "name": "serverless-sagemaker-groundtruth",
+    "description": "Serverless Plugin with AWS Sagemaker Groundtruth utilities (local template testing, e2e tests ...)",
+    "githubUrl": "https://github.com/piercus/serverless-sagemaker-groundtruth",
+    "status": "active"
 }, {
-  "name": "serverless-local-environment",
-  "description": "Serverless plugin to set local environment variables and remote environment variable to different values",
-  "githubUrl": "https://github.com/piercus/serverless-local-environment",
-  "status": "active"
+    "name": "serverless-local-environment",
+    "description": "Serverless plugin to set local environment variables and remote environment variable to different values",
+    "githubUrl": "https://github.com/piercus/serverless-local-environment",
+    "status": "active"
 }, {
-  "name": "serverless-offline-schedule",
-  "description": "Emulate schedule events locally when developing your Serverless project",
-  "githubUrl": "https://github.com/Meemaw/serverless-offline-schedule",
-  "status": "active"
+    "name": "serverless-offline-schedule",
+    "description": "Emulate schedule events locally when developing your Serverless project",
+    "githubUrl": "https://github.com/Meemaw/serverless-offline-schedule",
+    "status": "active"
 }, {
-  "name": "serverless-cloudformation-sub-variables",
-  "description": "Serverless framework plugin for easily supporting AWS CloudFormation Sub function variables",
-  "githubUrl": "https://github.com/santiagocardenas/serverless-cloudformation-sub-variables",
-  "status": "active"
+    "name": "serverless-cloudformation-sub-variables",
+    "description": "Serverless framework plugin for easily supporting AWS CloudFormation Sub function variables",
+    "githubUrl": "https://github.com/santiagocardenas/serverless-cloudformation-sub-variables",
+    "status": "active"
 }, {
-  "name": "serverless-sthree-env",
-  "description": "Serverless plugin to get config from a json formatted file in S3 and copy them to environment variable",
-  "githubUrl": "https://github.com/StyleTributeIT/serverless-sthree-env",
-  "status": "active"
+    "name": "serverless-sthree-env",
+    "description": "Serverless plugin to get config from a json formatted file in S3 and copy them to environment variable",
+    "githubUrl": "https://github.com/StyleTributeIT/serverless-sthree-env",
+    "status": "active"
 }, {
-  "name": "serverless-plugin-canary-deployments",
-  "description": "A Serverless plugin to implement canary deployments of Lambda functions",
-  "githubUrl": "https://github.com/davidgf/serverless-plugin-canary-deployments",
-  "status": "active"
+    "name": "serverless-plugin-canary-deployments",
+    "description": "A Serverless plugin to implement canary deployments of Lambda functions",
+    "githubUrl": "https://github.com/davidgf/serverless-plugin-canary-deployments",
+    "status": "active"
 }, {
-  "name": "serverless-go-build",
-  "description": "Build go source files (or public functions) using yml definition file",
-  "githubUrl": "https://github.com/sean9keenan/serverless-go-build",
-  "status": "active"
+    "name": "serverless-go-build",
+    "description": "Build go source files (or public functions) using yml definition file",
+    "githubUrl": "https://github.com/sean9keenan/serverless-go-build",
+    "status": "active"
 }, {
-  "name": "bref",
-  "description": "Deploy serverless PHP applications to AWS Lambda",
-  "githubUrl": "https://github.com/brefphp/bref",
-  "status": "active"
+    "name": "bref",
+    "description": "Deploy serverless PHP applications to AWS Lambda",
+    "githubUrl": "https://github.com/brefphp/bref",
+    "status": "active"
 }, {
-  "name": "serverless-local-schedule",
-  "description": "Schedule AWS CloudWatch Event based invocations in local time(with DST support!)",
-  "githubUrl": "https://github.com/UnitedIncome/serverless-local-schedule",
-  "status": "active"
+    "name": "serverless-local-schedule",
+    "description": "Schedule AWS CloudWatch Event based invocations in local time(with DST support!)",
+    "githubUrl": "https://github.com/UnitedIncome/serverless-local-schedule",
+    "status": "active"
 }, {
-  "name": "go-serverless",
-  "description": "GoFormation for Serverless. Create serverless configs with Go Structs.",
-  "githubUrl": "https://github.com/thepauleh/goserverless",
-  "status": "active"
+    "name": "go-serverless",
+    "description": "GoFormation for Serverless. Create serverless configs with Go Structs.",
+    "githubUrl": "https://github.com/thepauleh/goserverless",
+    "status": "active"
 }, {
-  "name": "serverless-tag-sqs",
-  "description": "Serverless plugin to tag SQS - Simple Queue Service",
-  "githubUrl": "https://github.com/gfragoso/serverless-tag-sqs",
-  "status": "active"
+    "name": "serverless-tag-sqs",
+    "description": "Serverless plugin to tag SQS - Simple Queue Service",
+    "githubUrl": "https://github.com/gfragoso/serverless-tag-sqs",
+    "status": "active"
 }, {
-  "name": "serverless-express",
-  "description": "Making express app development compatible with serverless framework.",
-  "githubUrl": "https://github.com/mikestaub/serverless-express",
-  "status": "active"
+    "name": "serverless-express",
+    "description": "Making express app development compatible with serverless framework.",
+    "githubUrl": "https://github.com/mikestaub/serverless-express",
+    "status": "active"
 }, {
-  "name": "serverless-aliyun-function-compute",
-  "description": "Serverless Alibaba Cloud Function Compute Plugin",
-  "githubUrl": "https://github.com/aliyun/serverless-aliyun-function-compute",
-  "status": "active"
+    "name": "serverless-aliyun-function-compute",
+    "description": "Serverless Alibaba Cloud Function Compute Plugin",
+    "githubUrl": "https://github.com/aliyun/serverless-aliyun-function-compute",
+    "status": "active"
 }, {
-  "name": "serverless-apib-validator",
-  "description": "Validate that an API Blueprint has full coverage over a Serverless config",
-  "githubUrl": "https://github.com/onlicar/serverless-apib-validator",
-  "status": "active"
+    "name": "serverless-apib-validator",
+    "description": "Validate that an API Blueprint has full coverage over a Serverless config",
+    "githubUrl": "https://github.com/onlicar/serverless-apib-validator",
+    "status": "active"
 }, {
-  "name": "serverless-package-common",
-  "description": "Deploy microservice Python Serverless services with common code",
-  "githubUrl": "https://github.com/onlicar/serverless-package-common",
-  "status": "active"
+    "name": "serverless-package-common",
+    "description": "Deploy microservice Python Serverless services with common code",
+    "githubUrl": "https://github.com/onlicar/serverless-package-common",
+    "status": "active"
 }, {
-  "name": "serverless-tag-api-gateway",
-  "description": "Serverless plugin to tag API Gateway",
-  "githubUrl": "https://github.com/gfragoso/serverless-tag-api-gateway",
-  "status": "active"
+    "name": "serverless-tag-api-gateway",
+    "description": "Serverless plugin to tag API Gateway",
+    "githubUrl": "https://github.com/gfragoso/serverless-tag-api-gateway",
+    "status": "active"
 }, {
-  "name": "serverless-tag-cloud-watch-logs",
-  "description": "Serverless plugin to tag CloudWatchLogs",
-  "githubUrl": "https://github.com/gfragoso/serverless-tag-cloud-watch-logs",
-  "status": "active"
+    "name": "serverless-tag-cloud-watch-logs",
+    "description": "Serverless plugin to tag CloudWatchLogs",
+    "githubUrl": "https://github.com/gfragoso/serverless-tag-cloud-watch-logs",
+    "status": "active"
 }, {
-  "name": "serverless-create-global-dynamodb-table",
-  "description": "Serverless plugin to create dynamodb global tables",
-  "githubUrl": "https://github.com/rrahul963/serverless-create-global-dynamodb-table",
-  "status": "active"
+    "name": "serverless-create-global-dynamodb-table",
+    "description": "Serverless plugin to create dynamodb global tables",
+    "githubUrl": "https://github.com/rrahul963/serverless-create-global-dynamodb-table",
+    "status": "active"
 }, {
-  "name": "serverless-ding",
-  "description": "Serverless plugin to audibly alert user after deployment",
-  "githubUrl": "https://github.com/sidgonuts/serverless-ding",
-  "status": "active"
+    "name": "serverless-ding",
+    "description": "Serverless plugin to audibly alert user after deployment",
+    "githubUrl": "https://github.com/sidgonuts/serverless-ding",
+    "status": "active"
 }, {
-  "name": "serverless-ignore",
-  "description": "Serverless plugin to ignore files (.slsignore)",
-  "githubUrl": "https://github.com/nya1/serverless-ignore",
-  "status": "active"
+    "name": "serverless-ignore",
+    "description": "Serverless plugin to ignore files (.slsignore)",
+    "githubUrl": "https://github.com/nya1/serverless-ignore",
+    "status": "active"
 }, {
-  "name": "serverless-add-api-key",
-  "description": "Serverless plugin to add same api key for multiple serverless services i.e. to re-use apikey across multiple api gateway apis.",
-  "githubUrl": "https://github.com/rrahul963/serverless-add-api-key",
-  "status": "active"
+    "name": "serverless-add-api-key",
+    "description": "Serverless plugin to add same api key for multiple serverless services i.e. to re-use apikey across multiple api gateway apis.",
+    "githubUrl": "https://github.com/rrahul963/serverless-add-api-key",
+    "status": "active"
 }, {
-  "name": "serverless-puresec-cli",
-  "description": "Serverless Plugin for magically creating IAM roles that are least privileged per function.",
-  "githubUrl": "https://github.com/puresec/serverless-puresec-cli",
-  "status": "active"
+    "name": "serverless-puresec-cli",
+    "description": "Serverless Plugin for magically creating IAM roles that are least privileged per function.",
+    "githubUrl": "https://github.com/puresec/serverless-puresec-cli",
+    "status": "active"
 }, {
-  "name": "serverless-dependson-plugin",
-  "description": "Serverless plugin that automatically generates DependsOn references for AWS Lambdas to prevent AWS RequestLimitExceeded errors.",
-  "githubUrl": "https://github.com/bwinant/serverless-dependson-plugin",
-  "status": "active"
+    "name": "serverless-dependson-plugin",
+    "description": "Serverless plugin that automatically generates DependsOn references for AWS Lambdas to prevent AWS RequestLimitExceeded errors.",
+    "githubUrl": "https://github.com/bwinant/serverless-dependson-plugin",
+    "status": "active"
 }, {
-  "name": "serverless-plugin-colocate",
-  "description": "Serverless Plugin to keep your configuration next to your code.",
-  "githubUrl": "https://github.com/aronim/serverless-plugin-colocate",
-  "status": "active"
+    "name": "serverless-plugin-colocate",
+    "description": "Serverless Plugin to keep your configuration next to your code.",
+    "githubUrl": "https://github.com/aronim/serverless-plugin-colocate",
+    "status": "active"
 }, {
-  "name": "serverless-plugin-fastdeploy",
-  "description": "Serverless Plugin to perform fast deployments for large service packages.",
-  "githubUrl": "https://github.com/aronim/serverless-plugin-fastdeploy",
-  "status": "active"
+    "name": "serverless-plugin-fastdeploy",
+    "description": "Serverless Plugin to perform fast deployments for large service packages.",
+    "githubUrl": "https://github.com/aronim/serverless-plugin-fastdeploy",
+    "status": "active"
 }, {
-  "name": "serverless-plugin-parent",
-  "description": "Serverless Plugin that allows you to keep common configuration in a parent serverless.yml",
-  "githubUrl": "https://github.com/aronim/serverless-plugin-parent",
-  "status": "active"
+    "name": "serverless-plugin-parent",
+    "description": "Serverless Plugin that allows you to keep common configuration in a parent serverless.yml",
+    "githubUrl": "https://github.com/aronim/serverless-plugin-parent",
+    "status": "active"
 }, {
-  "name": "serverless-plugin-registry",
-  "description": "Serverless plugin to register function names with AWS SSM Parameter Store.",
-  "githubUrl": "https://github.com/aronim/serverless-plugin-registry",
-  "status": "active"
+    "name": "serverless-plugin-registry",
+    "description": "Serverless plugin to register function names with AWS SSM Parameter Store.",
+    "githubUrl": "https://github.com/aronim/serverless-plugin-registry",
+    "status": "active"
 }, {
-  "name": "serverless-plugin-offline-dynamodb-stream",
-  "description": "Serverless Plugin for emulating dynamodb stream triggering lambda functions offline",
-  "githubUrl": "https://github.com/orchestrated-io/serverless-plugin-offline-dynamodb-stream",
-  "status": "active"
+    "name": "serverless-plugin-offline-dynamodb-stream",
+    "description": "Serverless Plugin for emulating dynamodb stream triggering lambda functions offline",
+    "githubUrl": "https://github.com/orchestrated-io/serverless-plugin-offline-dynamodb-stream",
+    "status": "active"
 }, {
-  "name": "serverless-basic-authentication",
-  "description": "Serverless Plugin for adding Basic Authentication to your api",
-  "githubUrl": "https://github.com/svdgraaf/serverless-basic-authentication",
-  "status": "active"
+    "name": "serverless-basic-authentication",
+    "description": "Serverless Plugin for adding Basic Authentication to your api",
+    "githubUrl": "https://github.com/svdgraaf/serverless-basic-authentication",
+    "status": "active"
 }, {
-  "name": "serverless-rust",
-  "description": "Deploy Rustlang applications to AWS Lambda",
-  "githubUrl": "https://github.com/softprops/serverless-rust",
-  "status": "active"
+    "name": "serverless-rust",
+    "description": "Deploy Rustlang applications to AWS Lambda",
+    "githubUrl": "https://github.com/softprops/serverless-rust",
+    "status": "active"
 }, {
-  "name": "sls-rust",
-  "description": "A Serverless plugin to deploy Rust applications",
-  "githubUrl": "https://github.com/fdaciuk/sls-rust",
-  "status": "active"
+    "name": "sls-rust",
+    "description": "A Serverless plugin to deploy Rust applications",
+    "githubUrl": "https://github.com/fdaciuk/sls-rust",
+    "status": "active"
 },{
-  "name": "serverless-oncall",
-  "description": "Easily manage oncall for your serverless services",
-  "githubUrl": "https://github.com/softprops/serverless-oncall",
-  "status": "active"
+    "name": "serverless-oncall",
+    "description": "Easily manage oncall for your serverless services",
+    "githubUrl": "https://github.com/softprops/serverless-oncall",
+    "status": "active"
 }, {
-  "name": "serverless-cognito-add-custom-attributes",
-  "description": "Serverless Plugin for adding custom attributes to an existing CloudFormation-managed CognitoUserPool and CognitoUserPoolClient without losing all your users",
-  "githubUrl": "https://github.com/GetWala/serverless-cognito-add-custom-attributes",
-  "status": "active"
+    "name": "serverless-cognito-add-custom-attributes",
+    "description": "Serverless Plugin for adding custom attributes to an existing CloudFormation-managed CognitoUserPool and CognitoUserPoolClient without losing all your users",
+    "githubUrl": "https://github.com/GetWala/serverless-cognito-add-custom-attributes",
+    "status": "active"
 }, {
-  "name": "serverless-plugin-ifelse",
-  "description": "A Serverless Plugin to write If Else conditions in serverless YAML file",
-  "githubUrl": "https://github.com/anantab/serverless-plugin-ifelse",
-  "status": "active"
+    "name": "serverless-plugin-ifelse",
+    "description": "A Serverless Plugin to write If Else conditions in serverless YAML file",
+    "githubUrl": "https://github.com/anantab/serverless-plugin-ifelse",
+    "status": "active"
 }, {
-  "name": "serverless-print-dots",
-  "description": "A Serverless plugin for printing dots in Serverless log during deployment to indicate progress and prevent timeouts in CI/CD platforms.",
-  "githubUrl": "https://github.com/amirklick/serverless-print-dots",
-  "status": "active"
+    "name": "serverless-print-dots",
+    "description": "A Serverless plugin for printing dots in Serverless log during deployment to indicate progress and prevent timeouts in CI/CD platforms.",
+    "githubUrl": "https://github.com/amirklick/serverless-print-dots",
+    "status": "active"
 }, {
-  "name": "serverless-es-logs",
-  "description": "A Serverless plugin to transport logs to ElasticSearch",
-  "githubUrl": "https://github.com/daniel-cottone/serverless-es-logs",
-  "status": "active"
+    "name": "serverless-es-logs",
+    "description": "A Serverless plugin to transport logs to ElasticSearch",
+    "githubUrl": "https://github.com/daniel-cottone/serverless-es-logs",
+    "status": "active"
 }, {
-  "name": "serverless-whitelisting",
-  "description": "A Serverless plugin to create a whitelist for IP addresses, CIDR for a serverless application, using resource policies. Support privateStages, publicStages and publicPaths.",
-  "githubUrl": "https://github.com/tho-asterist/serverless-whitelisting",
-  "status": "active"
+    "name": "serverless-whitelisting",
+    "description": "A Serverless plugin to create a whitelist for IP addresses, CIDR for a serverless application, using resource policies. Support privateStages, publicStages and publicPaths.",
+    "githubUrl": "https://github.com/tho-asterist/serverless-whitelisting",
+    "status": "active"
 }, {
-  "name": "serverless-package-external",
-  "description": "A Serverless plugin to add external folders to the deploy package",
-  "githubUrl": "https://github.com/epsagon/serverless-package-external",
-  "status": "active"
+    "name": "serverless-package-external",
+    "description": "A Serverless plugin to add external folders to the deploy package",
+    "githubUrl": "https://github.com/epsagon/serverless-package-external",
+    "status": "active"
 }, {
-  "name": "serverless-consul-variables",
-  "description": "Retrieve serverless variables from Consul kv",
-  "githubUrl": "https://github.com/zephrax/serverless-consul-variables",
-  "status": "active"
+    "name": "serverless-consul-variables",
+    "description": "Retrieve serverless variables from Consul kv",
+    "githubUrl": "https://github.com/zephrax/serverless-consul-variables",
+    "status": "active"
 }, {
-  "name": "serverless-iot-offline",
-  "description": "Serverless plugin that emulates AWS IoT service",
-  "githubUrl": "https://github.com/mitipi/serverless-iot-offline",
-  "status": "active"
+    "name": "serverless-iot-offline",
+    "description": "Serverless plugin that emulates AWS IoT service",
+    "githubUrl": "https://github.com/mitipi/serverless-iot-offline",
+    "status": "active"
 }, {
-  "name": "serverless-ngrok-tunnel",
-  "description": "Serverless plugin that creates ngrok public tunnel on localhost",
-  "githubUrl": "https://github.com/mitipi/serverless-ngrok-tunnel",
-  "status": "active"
+    "name": "serverless-ngrok-tunnel",
+    "description": "Serverless plugin that creates ngrok public tunnel on localhost",
+    "githubUrl": "https://github.com/mitipi/serverless-ngrok-tunnel",
+    "status": "active"
 }, {
-  "name": "serverless-oauth-scopes",
-  "description": "A serverless plugin to set OAuth Scopes on APIGateway methods",
-  "githubUrl": "https://github.com/birdcatcher/serverless-oauth-scopes",
-  "status": "active"
+    "name": "serverless-oauth-scopes",
+    "description": "A serverless plugin to set OAuth Scopes on APIGateway methods",
+    "githubUrl": "https://github.com/birdcatcher/serverless-oauth-scopes",
+    "status": "active"
 }, {
-  "name": "@haftahave/serverless-ses-template",
-  "description": "A serveless plugin that allows automatically creating, updating and removing AWS SES Templates using a configuration file and keeps your AWS SES Templates synced with your configuration file.",
-  "githubUrl": "https://github.com/haftahave/serverless-ses-template",
-  "status": "active"
+    "name": "@haftahave/serverless-ses-template",
+    "description": "A serveless plugin that allows automatically creating, updating and removing AWS SES Templates using a configuration file and keeps your AWS SES Templates synced with your configuration file.",
+    "githubUrl": "https://github.com/haftahave/serverless-ses-template",
+    "status": "active"
 }, {
-  "name": "serverless-api-gateway-caching",
-  "description": "Serverless plugin which configures API Gateway caching",
-  "githubUrl": "https://github.com/DianaIonita/serverless-api-gateway-caching",
-  "status": "active"
+    "name": "serverless-api-gateway-caching",
+    "description": "Serverless plugin which configures API Gateway caching",
+    "githubUrl": "https://github.com/DianaIonita/serverless-api-gateway-caching",
+    "status": "active"
 }, {
-  "name": "serverless-api-gateway-throttling",
-  "description": "Serverless plugin which configures throttling for API Gateway endpoints",
-  "githubUrl": "https://github.com/DianaIonita/serverless-api-gateway-throttling",
-  "status": "active"
+    "name": "serverless-api-gateway-throttling",
+    "description": "Serverless plugin which configures throttling for API Gateway endpoints",
+    "githubUrl": "https://github.com/DianaIonita/serverless-api-gateway-throttling",
+    "status": "active"
 }, {
-  "name": "serverless-vpc-plugin",
-  "description": "Serverless plugin to create a VPC",
-  "githubUrl": "https://github.com/smoketurner/serverless-vpc-plugin",
-  "status": "active"
+    "name": "serverless-vpc-plugin",
+    "description": "Serverless plugin to create a VPC",
+    "githubUrl": "https://github.com/smoketurner/serverless-vpc-plugin",
+    "status": "active"
 }, {
-  "name": "serverless-plugin-monorepo",
-  "description": "A serverless plugin that allows use of serverless in a mono repo. Avoids needing to use nohoist by automatic symlinking of all dependencies.",
-  "githubUrl": "https://github.com/Butterwire/serverless-plugin-monorepo",
-  "status": "active"
+    "name": "serverless-plugin-monorepo",
+    "description": "A serverless plugin that allows use of serverless in a mono repo. Avoids needing to use nohoist by automatic symlinking of all dependencies.",
+    "githubUrl": "https://github.com/Butterwire/serverless-plugin-monorepo",
+    "status": "active"
 }, {
-  "name": "serverless-version-tracker",
-  "description": "A serverless plugin for tracking deployed versions of your code.",
-  "githubUrl": "https://github.com/danepowell/serverless-version-tracker",
-  "status": "active"
+    "name": "serverless-version-tracker",
+    "description": "A serverless plugin for tracking deployed versions of your code.",
+    "githubUrl": "https://github.com/danepowell/serverless-version-tracker",
+    "status": "active"
 }, {
-  "name": "serverless-confirm-command",
-  "description": "Make commands (and provider-specific options) requiring confirmation before execution.",
-  "githubUrl": "https://github.com/teddy-gustiaux/serverless-confirm-command",
-  "status": "active"
+    "name": "serverless-confirm-command",
+    "description": "Make commands (and provider-specific options) requiring confirmation before execution.",
+    "githubUrl": "https://github.com/teddy-gustiaux/serverless-confirm-command",
+    "status": "active"
 }, {
-  "name": "serverless-workspaces-plugin",
-  "description": "Resolve and Symlink hoisted dependencies when individually packaging each function",
-  "githubUrl": "https://github.com/sergioramos/serverless-workspaces-plugin",
-  "status": "inactive"
+    "name": "serverless-workspaces-plugin",
+    "description": "Resolve and Symlink hoisted dependencies when individually packaging each function",
+    "githubUrl": "https://github.com/sergioramos/serverless-workspaces-plugin",
+    "status": "inactive"
 }, {
-  "name": "serverless-cloudflare-workers",
-  "description": "A serverless plugin allowing you to integrate with [Cloudflare Workers](https://cloudflareworkers.com/#12a9195720fe4ed660949efdbd9c0219:https://tutorial.cloudflareworkers.com)",
-  "githubUrl": "https://github.com/cloudflare/serverless-cloudflare-workers",
-  "status": "active"
+    "name": "serverless-cloudflare-workers",
+    "description": "A serverless plugin allowing you to integrate with [Cloudflare Workers](https://cloudflareworkers.com/#12a9195720fe4ed660949efdbd9c0219:https://tutorial.cloudflareworkers.com)",
+    "githubUrl": "https://github.com/cloudflare/serverless-cloudflare-workers",
+    "status": "active"
 }, {
-  "name": "@endemolshinegroup/serverless-dynamodb-autoscaler",
-  "description": "Autoscale DynamoDB resources with a single AWS AutoScalingPlan",
-  "githubUrl": "https://github.com/EndemolShineGroup/serverless-dynamodb-autoscaler",
-  "status": "active"
+    "name": "@endemolshinegroup/serverless-dynamodb-autoscaler",
+    "description": "Autoscale DynamoDB resources with a single AWS AutoScalingPlan",
+    "githubUrl": "https://github.com/EndemolShineGroup/serverless-dynamodb-autoscaler",
+    "status": "active"
 }, {
   "name": "serverless-plugin-decouple",
   "description": "Remove ImportValue dependencies by replacing them with the actual values in order to update base exports",
   "githubUrl": "https://github.com/mutual-of-enumclaw/serverless-plugin-decouple",
   "status": "active"
 }, {
-  "name": "serverless-docker-artifacts",
-  "description": "Build your artifacts within docker container.",
-  "githubUrl": "https://github.com/Suor/serverless-docker-artifacts",
-  "status": "active"
+    "name": "serverless-docker-artifacts",
+    "description": "Build your artifacts within docker container.",
+    "githubUrl": "https://github.com/Suor/serverless-docker-artifacts",
+    "status": "active"
 }, {
-  "name": "serverless-tesseract",
-  "description": "Add Tesseract OCR Engine to your build.",
-  "githubUrl": "https://github.com/Suor/serverless-tesseract",
-  "status": "active"
+    "name": "serverless-tesseract",
+    "description": "Add Tesseract OCR Engine to your build.",
+    "githubUrl": "https://github.com/Suor/serverless-tesseract",
+    "status": "active"
 }, {
-  "name": "aws-cognito-idp-userpool-domain",
-  "description": "Manage (add and remove) aws hosted domain on Cognito Userpools",
-  "githubUrl": "https://github.com/rubentrancoso/aws-cognito-idp-userpool-domain",
-  "status": "active"
+    "name": "aws-cognito-idp-userpool-domain",
+    "description": "Manage (add and remove) aws hosted domain on Cognito Userpools",
+    "githubUrl": "https://github.com/rubentrancoso/aws-cognito-idp-userpool-domain",
+    "status": "active"
 }, {
-  "name": "serverless-parcel",
-  "description": "A Serverless plugin to bundle your functions and assets with Parcel Bundler",
-  "githubUrl": "https://github.com/johnagan/serverless-parcel",
-  "status": "active"
+    "name": "serverless-parcel",
+    "description": "A Serverless plugin to bundle your functions and assets with Parcel Bundler",
+    "githubUrl": "https://github.com/johnagan/serverless-parcel",
+    "status": "active"
 }, {
-  "name": "serverless-vault-plugin",
-  "description": "A Serverless plugin to retrieve passwords from vault and encrypt to kms",
-  "githubUrl": "https://github.com/Rondineli/serverless-vault-plugin",
-  "status": "active"
+    "name": "serverless-vault-plugin",
+    "description": "A Serverless plugin to retrieve passwords from vault and encrypt to kms",
+    "githubUrl": "https://github.com/Rondineli/serverless-vault-plugin",
+    "status": "active"
 }, {
-  "name": "serverless-function-outputs",
-  "description": "Adds function Name and ARN outputs without version suffix",
-  "githubUrl": "https://github.com/RogerBarreto/serverless-function-outputs",
-  "status": "active"
+    "name": "serverless-function-outputs",
+    "description": "Adds function Name and ARN outputs without version suffix",
+    "githubUrl": "https://github.com/RogerBarreto/serverless-function-outputs",
+    "status": "active"
 }, {
   "name": "serverless-website-domain",
   "description": "A plugin that creates Route 53 records that point to your Cloudfront hosted static website, including www/non-www redirects.",
   "githubUrl": "https://github.com/williamsandonz/serverless-website-domain",
   "status": "active"
 },
-  {
-    "name": "serverless-output-to-env",
-    "description": "A Serverless plugin that writes stack outputs to an .env file during the after:deploy hook.",
-    "githubUrl": "https://github.com/williamsandonz/serverless-output-to-env",
-    "status": "active"
-  },
-  {
+{
+  "name": "serverless-output-to-env",
+  "description": "A Serverless plugin that writes stack outputs to an .env file during the after:deploy hook.",
+  "githubUrl": "https://github.com/williamsandonz/serverless-output-to-env",
+  "status": "active"
+},
+{
     "name": "serverless-kms-grants",
     "description": "Create and revoke grants for AWS Lambda functions to use KMS keys.",
     "githubUrl": "https://github.com/deep-security/serverless-kms-grants",
     "status": "active"
-  }, {
-  "name": "serverless-rack",
-  "description": "Serverless plugin to deploy Ruby Rack applications (Sinatra/Padrino/Cuba etc.)",
-  "githubUrl": "https://github.com/logandk/serverless-rack",
-  "status": "active"
 }, {
-  "name": "serverless-ruby-package",
-  "description": "Improves packaging and deploying gems for Ruby services",
-  "githubUrl": "https://github.com/joshuaflanagan/serverless-ruby-package",
-  "status": "active"
+    "name": "serverless-rack",
+    "description": "Serverless plugin to deploy Ruby Rack applications (Sinatra/Padrino/Cuba etc.)",
+    "githubUrl": "https://github.com/logandk/serverless-rack",
+    "status": "active"
 }, {
-  "name": "serverless-plugin-parcel",
-  "description": "Serverless Parcel plugin with watch mode and serverless-offline support",
-  "githubUrl": "https://github.com/threadheap/serverless-plugin-parcel",
-  "status": "active"
+    "name": "serverless-ruby-package",
+    "description": "Improves packaging and deploying gems for Ruby services",
+    "githubUrl": "https://github.com/joshuaflanagan/serverless-ruby-package",
+    "status": "active"
 }, {
-  "name": "serverless-plugin-tree-shake",
-  "description": "Shake the dependency tree and only package files needed",
-  "githubUrl": "https://github.com/sergioramos/serverless-plugin-tree-shake",
-  "status": "active"
+    "name": "serverless-plugin-parcel",
+    "description": "Serverless Parcel plugin with watch mode and serverless-offline support",
+    "githubUrl": "https://github.com/threadheap/serverless-plugin-parcel",
+    "status": "active"
 }, {
-  "name": "serverless-plugin-typescript-express",
-  "description": "Serverless plugin Typescript support with express integration",
-  "githubUrl": "https://github.com/eliasjcjunior/serverless-plugin-typescript-express",
-  "status": "active"
+    "name": "serverless-plugin-tree-shake",
+    "description": "Shake the dependency tree and only package files needed",
+    "githubUrl": "https://github.com/sergioramos/serverless-plugin-tree-shake",
+    "status": "active"
 }, {
-  "name": "serverless-aws-static-file-handler",
-  "description": "An easy way to host the front-end of your web applications on Serverless framework on AWS Lambda along with their APIs written in Serverless.",
-  "githubUrl": "https://github.com/activescott/serverless-aws-static-file-handler",
-  "status": "active"
+    "name": "serverless-plugin-typescript-express",
+    "description": "Serverless plugin Typescript support with express integration",
+    "githubUrl": "https://github.com/eliasjcjunior/serverless-plugin-typescript-express",
+    "status": "active"
 }, {
-  "name": "serverless-http-invoker",
-  "description": "Locally invoke Serverless functions via their HTTP event as specified in Serverless.yml. It makes it easy to test not only your handler logic, but also ensures that you have your http events setup properly in serverless.yml without deploying.",
-  "githubUrl": "https://github.com/activescott/serverless-http-invoker",
-  "status": "active"
+    "name": "serverless-aws-static-file-handler",
+    "description": "An easy way to host the front-end of your web applications on Serverless framework on AWS Lambda along with their APIs written in Serverless.",
+    "githubUrl": "https://github.com/activescott/serverless-aws-static-file-handler",
+    "status": "active"
 }, {
-  "name": "serverless-plugin-cloudwatch-dashboard",
-  "description": "Serverless plugin to generate AWS CloudWatch dashboard for AWS Lambda functions",
-  "githubUrl": "https://github.com/codecentric/serverless-plugin-cloudwatch-dashboard",
-  "status": "active"
+    "name": "serverless-http-invoker",
+    "description": "Locally invoke Serverless functions via their HTTP event as specified in Serverless.yml. It makes it easy to test not only your handler logic, but also ensures that you have your http events setup properly in serverless.yml without deploying.",
+    "githubUrl": "https://github.com/activescott/serverless-http-invoker",
+    "status": "active"
 }, {
-  "name": "serverless-create-dynamodb-global-tables-for-cf-stack",
-  "description": "Create and replicate global dynamodb tables",
-  "githubUrl": "https://github.com/Imran99/serverless-create-dynamodb-global-tables-for-cf-stack",
-  "status": "active"
+    "name": "serverless-plugin-cloudwatch-dashboard",
+    "description": "Serverless plugin to generate AWS CloudWatch dashboard for AWS Lambda functions",
+    "githubUrl": "https://github.com/codecentric/serverless-plugin-cloudwatch-dashboard",
+    "status": "active"
 }, {
-  "name": "serverless-tencent-scf",
-  "description": "Serverless framework provider plugin for Tencent SCF(Serverless Cloud Function)",
-  "githubUrl": "https://github.com/tencentyun/serverless-tencent-cloud-function",
-  "status": "active"
+    "name": "serverless-create-dynamodb-global-tables-for-cf-stack",
+    "description": "Create and replicate global dynamodb tables",
+    "githubUrl": "https://github.com/Imran99/serverless-create-dynamodb-global-tables-for-cf-stack",
+    "status": "active"
 }, {
-  "name": "serverless-plugin-staging",
-  "description": "A plugin to restrict the deployment of resources or functions on a per stage basis",
-  "githubUrl": "https://github.com/icarus-sullivan/serverless-plugin-staging",
-  "status": "active"
+    "name": "serverless-tencent-scf",
+    "description": "Serverless framework provider plugin for Tencent SCF(Serverless Cloud Function)",
+    "githubUrl": "https://github.com/tencentyun/serverless-tencent-cloud-function",
+    "status": "active"
 }, {
-  "name": "serverless-fargate-tasks",
-  "description": "A plugin to run fargate tasks as part of your Serverless project",
-  "githubUrl": "https://github.com/svdgraaf/serverless-fargate-tasks",
-  "status": "active"
+    "name": "serverless-plugin-staging",
+    "description": "A plugin to restrict the deployment of resources or functions on a per stage basis",
+    "githubUrl": "https://github.com/icarus-sullivan/serverless-plugin-staging",
+    "status": "active"
 }, {
-  "name": "serverless-plugin-composed-vars",
-  "description": "A plugin that composes custom and environment variables based on the deployment stage",
-  "githubUrl": "https://github.com/chris-feist/serverless-plugin-composed-vars",
-  "status": "active"
+    "name": "serverless-fargate-tasks",
+    "description": "A plugin to run fargate tasks as part of your Serverless project",
+    "githubUrl": "https://github.com/svdgraaf/serverless-fargate-tasks",
+    "status": "active"
 }, {
-  "name": "serverless-multi-region-plugin",
-  "description": "A plugin for setting up a serverless API in AWS with turnkey multi-region failover",
-  "githubUrl": "https://github.com/unbill/serverless-multi-region-plugin",
-  "status": "active"
+    "name": "serverless-plugin-composed-vars",
+    "description": "A plugin that composes custom and environment variables based on the deployment stage",
+    "githubUrl": "https://github.com/chris-feist/serverless-plugin-composed-vars",
+    "status": "active"
 }, {
-  "name": "serverless-plugin-pubsub",
-  "description": "Simple pub/sub configuration with queueing for the Serverless Framework",
-  "githubUrl": "https://github.com/fivepapertigers/serverless-plugin-pubsub",
-  "status": "active"
+    "name": "serverless-multi-region-plugin",
+    "description": "A plugin for setting up a serverless API in AWS with turnkey multi-region failover",
+    "githubUrl": "https://github.com/unbill/serverless-multi-region-plugin",
+    "status": "active"
 }, {
-  "name": "serverless-import-apigateway",
-  "description": "Dynamically import an existing AWS API Gateway into your Serverless stack",
-  "githubUrl": "https://github.com/mikesouza/serverless-import-apigateway",
-  "status": "active"
+    "name": "serverless-plugin-pubsub",
+    "description": "Simple pub/sub configuration with queueing for the Serverless Framework",
+    "githubUrl": "https://github.com/fivepapertigers/serverless-plugin-pubsub",
+    "status": "active"
 }, {
-  "name": "serverless-associate-waf",
-  "description": "Associate a regional WAF with the AWS API Gateway used by your Serverless stack",
-  "githubUrl": "https://github.com/mikesouza/serverless-associate-waf",
-  "status": "active"
+    "name": "serverless-import-apigateway",
+    "description": "Dynamically import an existing AWS API Gateway into your Serverless stack",
+    "githubUrl": "https://github.com/mikesouza/serverless-import-apigateway",
+    "status": "active"
 }, {
-  "name": "serverless-deployment-bucket",
-  "description": "Create and configure the custom Serverless deployment bucket",
-  "githubUrl": "https://github.com/mikesouza/serverless-deployment-bucket",
-  "status": "active"
+    "name": "serverless-associate-waf",
+    "description": "Associate a regional WAF with the AWS API Gateway used by your Serverless stack",
+    "githubUrl": "https://github.com/mikesouza/serverless-associate-waf",
+    "status": "active"
 }, {
-  "name": "serverless-manifest-plugin",
-  "description": "Generate manifest of api endpoints & stack outputs for consumption in other applications + service discovery",
-  "githubUrl": "https://github.com/DavidWells/serverless-manifest-plugin",
-  "status": "active"
+    "name": "serverless-deployment-bucket",
+    "description": "Create and configure the custom Serverless deployment bucket",
+    "githubUrl": "https://github.com/mikesouza/serverless-deployment-bucket",
+    "status": "active"
 }, {
-  "name": "serverless-local-kinesis",
-  "description": "Run a local kinesis and automatically fire events",
-  "githubUrl": "https://github.com/pidz-development/serverless-local-kinesis",
-  "status": "active"
+    "name": "serverless-manifest-plugin",
+    "description": "Generate manifest of api endpoints & stack outputs for consumption in other applications + service discovery",
+    "githubUrl": "https://github.com/DavidWells/serverless-manifest-plugin",
+    "status": "active"
 }, {
-  "name": "serverless-nextjs-plugin",
-  "description": "Deploy serverless next apps with ease",
-  "githubUrl": "https://github.com/danielcondemarin/serverless-nextjs-plugin",
-  "status": "active"
+    "name": "serverless-local-kinesis",
+    "description": "Run a local kinesis and automatically fire events",
+    "githubUrl": "https://github.com/pidz-development/serverless-local-kinesis",
+    "status": "active"
 }, {
-  "name": "serverless-plugin-tables",
-  "description": "Easily configure table resources, such as DynamoDB",
-  "githubUrl": "https://github.com/chris-feist/serverless-plugin-tables",
-  "status": "active"
+    "name": "serverless-nextjs-plugin",
+    "description": "Deploy serverless next apps with ease",
+    "githubUrl": "https://github.com/danielcondemarin/serverless-nextjs-plugin",
+    "status": "active"
 }, {
-  "name": "serverless-iopipe-layers",
-  "description": "Monitor, observe and profile your AWS Lambda functions without a code change",
-  "githubUrl": "https://github.com/iopipe/serverless-iopipe-layers",
-  "status": "active"
+    "name": "serverless-plugin-tables",
+    "description": "Easily configure table resources, such as DynamoDB",
+    "githubUrl": "https://github.com/chris-feist/serverless-plugin-tables",
+    "status": "active"
 }, {
-  "name": "serverless-cloudside-plugin",
-  "description": "Easily reference and use cloudside resources during local development and testing",
-  "githubUrl": "https://github.com/jeremydaly/serverless-cloudside-plugin",
-  "status": "active"
+    "name": "serverless-iopipe-layers",
+    "description": "Monitor, observe and profile your AWS Lambda functions without a code change",
+    "githubUrl": "https://github.com/iopipe/serverless-iopipe-layers",
+    "status": "active"
 }, {
-  "name": "serverless-jetpack",
-  "description": "A faster JavaScript packager for Serverless applications",
-  "githubUrl": "https://github.com/FormidableLabs/serverless-jetpack",
-  "status": "active"
+    "name": "serverless-cloudside-plugin",
+    "description": "Easily reference and use cloudside resources during local development and testing",
+    "githubUrl": "https://github.com/jeremydaly/serverless-cloudside-plugin",
+    "status": "active"
 }, {
-  "name": "serverless-offline-http-mock",
-  "description": "Create mock responses to HTTP(S) requests for local development",
-  "githubUrl": "https://github.com/pianomansam/serverless-offline-http-mock",
-  "status": "active"
+    "name": "serverless-jetpack",
+    "description": "A faster JavaScript packager for Serverless applications",
+    "githubUrl": "https://github.com/FormidableLabs/serverless-jetpack",
+    "status": "active"
 }, {
-  "name": "serverless-externals-plugin",
-  "description": "Only include listed node modules and their dependencies in Serverless, with support for Rollup and Webpack",
-  "githubUrl": "https://github.com/hansottowirtz/serverless-externals-plugin",
-  "status": "active"
+    "name": "serverless-offline-http-mock",
+    "description": "Create mock responses to HTTP(S) requests for local development",
+    "githubUrl": "https://github.com/pianomansam/serverless-offline-http-mock",
+    "status": "active"
 }, {
-  "name": "api-gateway-stage-tag-plugin",
-  "description": "A shim to tag API Gateway stages until CloudFormation/Serverless support arrives.",
-  "githubUrl": "https://github.com/mikepatrick/api-gateway-stage-tag-plugin",
-  "status": "active"
+    "name": "serverless-externals-plugin",
+    "description": "Only include listed node modules and their dependencies in Serverless, with support for Rollup and Webpack",
+    "githubUrl": "https://github.com/hansottowirtz/serverless-externals-plugin",
+    "status": "active"
 }, {
-  "name": "serverless-api-compression",
-  "description": "Serverless plugin that enables/disables content compression setting in API Gateway",
-  "githubUrl": "https://github.com/evgenykireev/serverless-api-compression",
-  "status": "active"
+    "name": "api-gateway-stage-tag-plugin",
+    "description": "A shim to tag API Gateway stages until CloudFormation/Serverless support arrives.",
+    "githubUrl": "https://github.com/mikepatrick/api-gateway-stage-tag-plugin",
+    "status": "active"
 }, {
-  "name": "serverless-aws-documentation",
-  "description": "Serverless 1.0 plugin to add documentation and models to the serverless generated API Gateway",
-  "githubUrl": "https://github.com/deliveryhero/serverless-aws-documentation",
-  "status": "active"
+    "name": "serverless-api-compression",
+    "description": "Serverless plugin that enables/disables content compression setting in API Gateway",
+    "githubUrl": "https://github.com/evgenykireev/serverless-api-compression",
+    "status": "active"
 }, {
-  "name": "serverless-http",
-  "description": "Use your existing middleware framework (e.g. Express, Koa) in AWS Lambda",
-  "githubUrl": "https://github.com/dougmoscrop/serverless-http",
-  "status": "active"
+    "name": "serverless-aws-documentation",
+    "description": "Serverless 1.0 plugin to add documentation and models to the serverless generated API Gateway",
+    "githubUrl": "https://github.com/deliveryhero/serverless-aws-documentation",
+    "status": "active"
 }, {
-  "name": "serverless-snowflake-external-function-plugin",
-  "description": "Serverless Plugin for deploying Snowflake External Functions",
-  "githubUrl": "https://github.com/starschema/serverless-snowflake-external-function-plugin",
-  "status": "active"
+    "name": "serverless-http",
+    "description": "Use your existing middleware framework (e.g. Express, Koa) in AWS Lambda",
+    "githubUrl": "https://github.com/dougmoscrop/serverless-http",
+    "status": "active"
 }, {
-  "name": "serverless-mysql",
-  "description": "A module for managing MySQL connections at SERVERLESS scale",
-  "githubUrl": "https://github.com/jeremydaly/serverless-mysql",
-  "status": "active"
+    "name": "serverless-snowflake-external-function-plugin",
+    "description": "Serverless Plugin for deploying Snowflake External Functions",
+    "githubUrl": "https://github.com/starschema/serverless-snowflake-external-function-plugin",
+    "status": "active"
 }, {
-  "name": "serverless-offline-kinesis",
-  "description": "This Serverless-offline-kinesis plugin emulates AWS λ and Kinesis streams on your local machine.",
-  "githubUrl": "https://github.com/CoorpAcademy/serverless-plugins/tree/master/packages/serverless-offline-kinesis",
-  "status": "active"
+    "name": "serverless-mysql",
+    "description": "A module for managing MySQL connections at SERVERLESS scale",
+    "githubUrl": "https://github.com/jeremydaly/serverless-mysql",
+    "status": "active"
 }, {
-  "name": "serverless-offline-python",
-  "description": "Emulate AWS λ and API Gateway locally when developing your Serverless project",
-  "githubUrl": "https://github.com/alhazmy13/serverless-offline-python",
-  "status": "active"
+    "name": "serverless-offline-kinesis",
+    "description": "This Serverless-offline-kinesis plugin emulates AWS λ and Kinesis streams on your local machine.",
+    "githubUrl": "https://github.com/CoorpAcademy/serverless-plugins/tree/master/packages/serverless-offline-kinesis",
+    "status": "active"
 }, {
-  "name": "serverless-openapi-documentation",
-  "description": "Serverless 1.0 plugin to generate OpenAPI V3 documentation from serverless configuration",
-  "githubUrl": "https://github.com/temando/serverless-openapi-documentation",
-  "status": "active"
+    "name": "serverless-offline-python",
+    "description": "Emulate AWS λ and API Gateway locally when developing your Serverless project",
+    "githubUrl": "https://github.com/alhazmy13/serverless-offline-python",
+    "status": "active"
 }, {
-  "name": "serverless-openwhisk",
-  "description": "Adds Apache OpenWhisk support to the Serverless Framework!",
-  "githubUrl": "https://github.com/serverless/serverless-openwhisk",
-  "status": "active"
+    "name": "serverless-openapi-documentation",
+    "description": "Serverless 1.0 plugin to generate OpenAPI V3 documentation from serverless configuration",
+    "githubUrl": "https://github.com/temando/serverless-openapi-documentation",
+    "status": "active"
 }, {
-  "name": "serverless-plugin-cloudfront-lambda-edge",
-  "description": "Adds Lambda@Edge support to Serverless",
-  "githubUrl": "https://github.com/silvermine/serverless-plugin-cloudfront-lambda-edge",
-  "status": "active"
+    "name": "serverless-openwhisk",
+    "description": "Adds Apache OpenWhisk support to the Serverless Framework!",
+    "githubUrl": "https://github.com/serverless/serverless-openwhisk",
+    "status": "active"
 }, {
-  "name": "serverless-plugin-cronjob",
-  "description": "This plugin creates cronjobs out of your lambda functions.",
-  "githubUrl": "https://github.com/martinlindenberg/serverless-plugin-cronjob",
-  "status": "active"
+    "name": "serverless-plugin-cloudfront-lambda-edge",
+    "description": "Adds Lambda@Edge support to Serverless",
+    "githubUrl": "https://github.com/silvermine/serverless-plugin-cloudfront-lambda-edge",
+    "status": "active"
 }, {
-  "name": "serverless-plugin-custom-roles",
-  "description": "A Serverless plugin that makes creation of per function IAM roles easier.",
-  "githubUrl": "https://github.com/AntonBazhal/serverless-plugin-custom-roles",
-  "status": "active"
+    "name": "serverless-plugin-cronjob",
+    "description": "This plugin creates cronjobs out of your lambda functions.",
+    "githubUrl": "https://github.com/martinlindenberg/serverless-plugin-cronjob",
+    "status": "active"
 }, {
-  "name": "serverless-plugin-existing-s3",
-  "description": "Overcomes the CloudFormation limitation on attaching an event to an uncontrolled bucket, for Serverless.com 1.11.0+.",
-  "githubUrl": "https://github.com/matt-filion/serverless-external-s3-event",
-  "status": "active"
+    "name": "serverless-plugin-custom-roles",
+    "description": "A Serverless plugin that makes creation of per function IAM roles easier.",
+    "githubUrl": "https://github.com/AntonBazhal/serverless-plugin-custom-roles",
+    "status": "active"
 }, {
-  "name": "serverless-plugin-log-retention",
-  "description": "Control the retention of your serverless function's cloudwatch logs.",
-  "githubUrl": "https://github.com/ArtificerEntertainment/serverless-plugin-log-retention",
-  "status": "active"
+    "name": "serverless-plugin-existing-s3",
+    "description": "Overcomes the CloudFormation limitation on attaching an event to an uncontrolled bucket, for Serverless.com 1.11.0+.",
+    "githubUrl": "https://github.com/matt-filion/serverless-external-s3-event",
+    "status": "active"
 }, {
-  "name": "serverless-plugin-newman",
-  "description": "A serverless plugin for newman.",
-  "githubUrl": "https://github.com/rawphp/serverless-plugin-newman",
-  "status": "active"
+    "name": "serverless-plugin-log-retention",
+    "description": "Control the retention of your serverless function's cloudwatch logs.",
+    "githubUrl": "https://github.com/ArtificerEntertainment/serverless-plugin-log-retention",
+    "status": "active"
 }, {
-  "name": "serverless-plugin-tracing",
-  "description": "Enables AWS X-Ray (https://aws.amazon.com/xray/) for the entire Serverless stack or individual functions.",
-  "githubUrl": "https://github.com/alex-murashkin/serverless-plugin-tracing",
-  "status": "active"
+    "name": "serverless-plugin-newman",
+    "description": "A serverless plugin for newman.",
+    "githubUrl": "https://github.com/rawphp/serverless-plugin-newman",
+    "status": "active"
 }, {
-  "name": "serverless-s3-deploy",
-  "description": "Plugin for serverless to deploy files to a variety of S3 Buckets",
-  "githubUrl": "https://github.com/funkybob/serverless-s3-deploy",
-  "status": "active"
+    "name": "serverless-plugin-tracing",
+    "description": "Enables AWS X-Ray (https://aws.amazon.com/xray/) for the entire Serverless stack or individual functions.",
+    "githubUrl": "https://github.com/alex-murashkin/serverless-plugin-tracing",
+    "status": "active"
 }, {
-  "name": "serverless-scheduled-functions",
-  "description": "Schedule your serverless functions",
-  "githubUrl": "https://github.com/reactor-studio/serverless-scheduled-functions",
-  "status": "active"
+    "name": "serverless-s3-deploy",
+    "description": "Plugin for serverless to deploy files to a variety of S3 Buckets",
+    "githubUrl": "https://github.com/funkybob/serverless-s3-deploy",
+    "status": "active"
 }, {
-  "name": "serverless-step-functions-offline",
-  "description": "Emulate step functions locally when developing your Serverless project ",
-  "githubUrl": "https://github.com/vkkis93/serverless-step-functions-offline",
-  "status": "active"
-},
+    "name": "serverless-scheduled-functions",
+    "description": "Schedule your serverless functions",
+    "githubUrl": "https://github.com/reactor-studio/serverless-scheduled-functions",
+    "status": "active"
+}, {
+    "name": "serverless-step-functions-offline",
+    "description": "Emulate step functions locally when developing your Serverless project ",
+    "githubUrl": "https://github.com/vkkis93/serverless-step-functions-offline",
+    "status": "active"
+  },
   {
     "name": "serverless-configuration",
     "description": "Easily customize serverless.yml depending on the stage or whether running online/offline",
@@ -1845,6 +1845,7 @@
   {
     "name": "serverless-configure-lambda-logs",
     "description": "Plugin that configures Lambda logs with CloudWatch log groups and subscriptions",
-    "githubUrl": "https://github.com/vavasilva/serverless-configure-lamba-logs"
+    "githubUrl": "https://github.com/vavasilva/serverless-configure-lamba-logs",
+    "status": "active"
   }
 ]


### PR DESCRIPTION
This PR adds the serverless-configure-lambda-logs plugin to the community plugins list. The plugin helps configure Lambda logs with CloudWatch log groups and subscriptions, allowing better control over Lambda function logs.